### PR TITLE
Use single-ticket.php instead of the_content filter

### DIFF
--- a/class-awesome-support.php
+++ b/class-awesome-support.php
@@ -50,13 +50,13 @@ class Awesome_Support {
 		add_action( 'wpas_after_close_ticket', array( $this, 'notify_close' ), 10, 1 );
 
 		/**
-		 * Modify the ticket single page content.
+		 * Loads the ticket single page template.
 		 *
-		 * wpas_single_ticket() is located in includes/functions-templating.php
+		 * wpas_single_ticket_template() is located in includes/functions-templating.php
 		 *
 		 * @since  3.0.0
 		 */
-		add_filter( 'the_content', 'wpas_single_ticket', 10, 1 );
+		add_filter( 'single_template', 'wpas_single_ticket_template' );
 	}
 
 	/**

--- a/includes/functions-templating.php
+++ b/includes/functions-templating.php
@@ -13,83 +13,21 @@
  */
 
 /**
- * Alter page content for single ticket.
- *
- * In order to ensure maximum complatibility with all themes,
- * we hook onto the_content instead of changing the entire template
- * for ticket single.
- *
- * However, if the theme author has customized the single ticket template
- * we do not apply those modifications as the custom template will do the job.
+ * Loads a custom template file for the single-template
  *
  * @since  3.0.0
  * @param  string $content Post content
  * @return string          Ticket single
  */
-function wpas_single_ticket( $content ) {
+function wpas_single_ticket_template( $single_template ) {
 
 	global $post;
 
-	/* Remove the filter to avoid infinite loops. */
-	remove_filter( 'the_content', 'wpas_single_ticket' );
-
-	$slug = 'ticket';
-
-	/* Don't touch the admin */
-	if ( is_admin() ) {
-		return $content;
+	if ( $post->post_type !== 'ticket' ) {
+		return $single_template;
 	}
 
-	/* Only apply this on the ticket single. */
-	if ( $slug !== $post->post_type ) {
-		return $content;
-	}
-
-	/* Check if the current user can view the ticket */
-	if ( !wpas_can_view_ticket( $post->ID ) ) {
-		return wpas_notification( false, 13, false );
-	}
-
-	/* Get template name */
-	$template_path = get_page_template();
-	$template      = explode( '/', $template_path );
-	$count         = count( $template );
-	$template      = $template[$count-1];
-
-	/* Don't apply the modifications on a custom template */
-	if ( "single-$slug.php" === $template ) {
-		return $content;
-	}
-
-	/* Get the ticket content */
-	ob_start();
-
-	/**
-	 * Display possible messages to the visitor.
-	 */
-	if ( isset( $_GET['message'] ) ) {
-		wpas_notification( false, $_GET['message'] );
-	}
-
-	/**
-	 * wpas_frontend_plugin_page_top is executed at the top
-	 * of every plugin page on the front end.
-	 */
-	do_action( 'wpas_frontend_plugin_page_top', $post->ID, $post );
-
-	/**
-	 * Get the custom template.
-	 */
-	wpas_get_template( 'details' );
-
-	/**
-	 * Finally get the buffer content and return.
-	 * 
-	 * @var string
-	 */
-	$content = ob_get_clean();
-
-	return $content;
+	return wpas_locate_template( 'single-ticket' );
 
 }
 

--- a/themes/default/single-ticket.php
+++ b/themes/default/single-ticket.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Single Ticket Template.
+ * 
+ * This is a built-in template file. If you need to customize it, please,
+ * DO NOT modify this file directly. Instead, copy it to your theme's directory
+ * and then modify the code. If you modify this file directly, your changes
+ * will be overwritten during next update of the plugin.
+ */
+
+/* Exit if accessed directly */
+if( !defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+global $post;
+
+get_header();
+
+/**
+ * Display possible messages to the visitor.
+ */
+if ( isset( $_GET['message'] ) ) {
+	wpas_notification( false, $_GET['message'] );
+}
+
+/**
+ * wpas_frontend_plugin_page_top is executed at the top
+ * of every plugin page on the front end.
+ */
+do_action( 'wpas_frontend_plugin_page_top', $post->ID, $post );
+
+/**
+ * Get the custom template.
+ */
+while ( have_posts() ) : the_post();
+
+	wpas_get_template( 'details' );
+
+endwhile;
+
+get_footer();


### PR DESCRIPTION
You should use a single-ticket.php instead of the `the_content`
filter. The problem is, that if you're applying the `the_content`
filter to a widget, which is loading before the posts content, your
plugins single ticket content will be displayed in the widget area, not
in the posts content area. This is also why for example woocommerce is
solving it with an own template file.
