### PR TITLE
Use WPAS_URL for CSS URLs.

### DIFF
--- a/includes/functions-templating.php
+++ b/includes/functions-templating.php
@@ -236,21 +236,10 @@ function wpas_get_theme_stylesheet_uri() {
 	);
 
 	if ( ! $template ) {
-		$template =  WPAS_PATH . "themes/$theme/css/style.css";
+		$template =  WPAS_URL . "themes/$theme/css/style.css";
 	}
 
-	/* Remove the root path and replace backslashes by slashes */
-	$truncate = str_replace('\\', '/', str_replace( untrailingslashit( ABSPATH ), '', $template ) );
-
-	/* Make sure the truncated string doesn't start with a slash because we trailing slash the home URL) */
-	if ( '/' === substr( $truncate, 0, 1 ) ) {
-		$truncate = substr( $truncate, 1 );
-	}
-
-	/* Build the final URL to the resource */
-	$uri = trailingslashit( site_url() ) . $truncate;
-
-	return apply_filters( 'wpas_get_theme_stylesheet_uri', $uri ); 
+	return apply_filters( 'wpas_get_theme_stylesheet_uri', $template );
 
 }
 


### PR DESCRIPTION
@julien731 

The whole story with replacement does not work when WP is installed in a folder, and plugins - in another place ( see `WP_CONTENT_DIR` constant ).

And, because you already have the `WPAS_URL` correctly pointing to the plugin URL, nothing else is needed, I belive.