### PR TITLE
Allow post status 'inherit' if querying both read and unread replies

### DIFF
--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -761,7 +761,7 @@ function wpas_get_replies( $post_id, $status = 'any', $args = array(), $output =
 	);
 
 	if ( ! is_array( $status ) ) {
-		$status = (array) $status;
+		$status = explode(',', $status);
 	}
 
 	foreach ( $status as $key => $reply_status ) {
@@ -771,7 +771,9 @@ function wpas_get_replies( $post_id, $status = 'any', $args = array(), $output =
 	}
 
 	if ( empty( $status ) ) {
-		$status = 'any';
+		$status[] = 'any';
+	} else if ( count($status) == 2 ) {
+		$status[] = 'inherit';
 	}
 
 	$defaults = array(


### PR DESCRIPTION
Some replies (at least on my site) have the post_status field set to inherit, and will not display on the front-end. I fixed `wpas_get_replies()` to query also replies that have a post_status set to inherit  when both (read and unread) statuses are queried.


Side note:
I think handling the read-state of a reply in general with the post status is not a good idea. The plugin introdues many new post statuses (queued, pending, processing, unread, read, closed).
For example this would not allow a reply to be private (for whatever reason), and get a read/unread flag. The read state should be set by a meta value.
Moreover there seems to be meta value `_wpas_status` which is somehow redundant to the post_status.

The plugin might work "as is", but as soon as someone tries to hook into the query, things get very confusing (the bug this pull request is trying to fix occured without any other plugin hooking in, though)


