### PR TITLE
Added ticket_id to wpas_email_notifications_email filter

### DIFF
--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -629,7 +629,8 @@ class WPAS_Email_Notification {
 			'headers'         => $headers,
 			'attachments'     => ''
 			),
-			$case
+			$case,
+			$this->ticket_id
 		);
 
 		$mail = wp_mail( $email['recipient_email'], $email['subject'], $email['body'], $email['headers'] );


### PR DESCRIPTION
wpas_email_notifications_email isn't terribly useful as it - you can get the user, but you can't easily get other information about the ticket. Adding ticket_id as a 3rd argument will, without breaking any compatibility, allow easy modification of the email based on the ticket_id, or anything that can be found from the ticket_id.