### PR TITLE
Update ticket only when false, not zero

### DIFF
--- a/includes/class-agent.php
+++ b/includes/class-agent.php
@@ -107,7 +107,7 @@ class WPAS_Agent {
 
 		$count = get_user_meta( $this->agent_id, 'wpas_open_tickets', true );
 
-		if ( empty( $count ) ) {
+		if ( false === $count ) {
 			$count = count( $this->get_open_tickets() );
 			update_user_meta( $this->agent_id, 'wpas_open_tickets', $count );
 		}


### PR DESCRIPTION
Bug: When adding a ticket, if the open ticket count is zero, the new ticket count is 2 instead of 1 due to checking for empty (which could be a valid count of zero) instead of false.

So open_tickets counts 1 ticket, then ticket_plus increments it to 2.
