### PR TITLE
Use original filename for attachments

### DIFF
--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -240,8 +240,11 @@ class WPAS_File_Upload {
 				wp_die( __( 'You are not allowed to view this attachment', 'awesome-support' ) );
 			}
 
+			$filename = basename( $attachment->guid );
+
 			ini_set( 'user_agent', 'Awesome Support/' . WPAS_VERSION . '; ' . get_bloginfo( 'url' ) );
 			header( "Content-Type: $attachment->post_mime_type" );
+			header( "Content-Disposition: inline; filename=\"$filename\"" );
 			readfile( $attachment->guid );
 
 			die();


### PR DESCRIPTION
Returns original filename when downloading attached files. This also fixes an issue where there was no file extension when downloading attached files, making binary files (like zip) hard to open (at least on Windows).

I added `Content-Disposition: inline` so that browser will try to open files (because of images, pdfs, etc.), but if you think it should be downloaded instead of opened then put `Content-Disposition: attachment` instead.