### PR TITLE
Add actions before/after attachment delete in WPAS_File_Upload

### DIFF
--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -909,9 +909,29 @@ class WPAS_File_Upload {
 		$attachments = $this->get_attachments( $post_id );
 
 		if ( !empty( $attachments ) ) {
+			/**
+			 * wpas_attachments_before_delete fires before deleting attachments
+			 *
+			 * @since  3.3.3
+			 * @param  integer $post_id       ID of the post we're displaying attachments for
+			 * @param  array   $attachment    The attachment array
+			 */
+			do_action( 'wpas_attachments_before_delete', $post_id, $attachments );
+
 			foreach ( $attachments as $id => $attachment ) {
 				wp_delete_attachment( $id, true );
 			}
+
+			/**
+			 * wpas_attachments_after_delete fires after deleting attachments
+			 * to allow cleanup of attachment folders
+			 *
+			 * @since  3.3.3
+			 * @param  integer $post_id       ID of the post we're displaying attachments for
+			 * @param  array   $attachment    The attachment array
+			 */
+			do_action( 'wpas_attachments_after_delete', $post_id, $attachments );
+
 		}
 
 	}


### PR DESCRIPTION
Added email attachment support to Email Support addon. 

Email attachments are stored in wp-content/uploads/awesome-support/ticket_$ticket_id folder. The WPAS_File_Upload::delete_attachments deletes the attachment itself but leaves the attachment folder behind.

The ticket attachment folder needs to be removed as well as the .htaccess file in each folder. The new action wpas_attachments_after_delete allows this folder cleanup and will be handy for any addon needing to perform post attachment delete actions.

The Email Support addon will expect this action.
