### PR TITLE
File Attachment support in core AS File Upload class

### DIFF
--- a/includes/admin/functions-tools.php
+++ b/includes/admin/functions-tools.php
@@ -32,6 +32,12 @@ function wpas_system_tools() {
 		case 'delete_products':
 			wpas_delete_synced_products();
 			break;
+
+		case 'ticket_attachments':
+			wpas_delete_unclaimed_attachments();
+			break;
+
+
 	}
 
 	/* Redirect in "read-only" mode */
@@ -283,5 +289,42 @@ function wpas_check_templates_override( $dir ) {
 	}
 
 	return $overrides;
+
+}
+
+// Remove attachment folder
+function wpas_delete_unclaimed_attachments( ) {
+
+	$upload = wp_get_upload_dir();
+	$attachments_root = trailingslashit($upload['basedir']) . 'awesome-support/';
+
+	foreach(glob($attachments_root . 'ticket_*') as $folder)
+	{
+		$ticket_id = false;
+		$basename = basename($folder);
+		$post = false;
+
+		if( ($x_pos = strpos($basename, '_')) !== FALSE ) {
+			$ticket_id = substr( $basename, $x_pos + 1 );
+			$post = get_post(absint($ticket_id));
+
+			if(empty($post)) {
+
+				$it    = new RecursiveDirectoryIterator( $attachments_root . $basename, RecursiveDirectoryIterator::SKIP_DOTS );
+				$files = new RecursiveIteratorIterator( $it, RecursiveIteratorIterator::CHILD_FIRST );
+
+				foreach ( $files as $file ) {
+					if ( $file->isDir() ) {
+						rmdir( $file->getRealPath() );
+					} else {
+						unlink( $file->getRealPath() );
+					}
+				}
+				rmdir( $attachments_root . $basename );
+			}
+		}
+	}
+
+	return;
 
 }

--- a/includes/admin/views/system-tools.php
+++ b/includes/admin/views/system-tools.php
@@ -49,6 +49,10 @@ if ( isset( $_GET['done'] ) ) {
 		case 'delete_products':
 			$message = __( 'All products have been deleted', 'awesome-support' );
 			break;
+
+		case 'ticket_attachments':
+			$message = __( 'All unclaimed ticket attachment folders have been deleted', 'awesome-support' );
+			break;
 	}
 
 }
@@ -85,6 +89,13 @@ if ( isset( $message ) ) {
 			<td>
 				<a href="<?php echo wpas_tool_link( 'clear_taxonomies' ); ?>" class="button-secondary"><?php _e( 'Clear', 'awesome-support' ); ?></a>
 				<span class="wpas-system-tools-desc"><?php _e( 'Clear all terms from all custom taxonomies.', 'awesome-support' ); ?></span>
+			</td>
+		</tr>
+		<tr>
+			<td class="row-title"><label for="tablecell"><?php _e( 'Ticket Attachments', 'awesome-support' ); ?></label></td>
+			<td>
+				<a href="<?php echo wpas_tool_link( 'ticket_attachments' ); ?>" class="button-secondary"><?php _e( 'Clear', 'awesome-support' ); ?></a>
+				<span class="wpas-system-tools-desc"><?php _e( 'Clear unclaimed ticket attachment folders.', 'awesome-support' ); ?></span>
 			</td>
 		</tr>
 		<?php do_action( 'wpas_system_tools_table_after' ); ?>

--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -686,17 +686,15 @@ class WPAS_File_Upload {
 	 */
 	public function process_attachments( $post_id, $attachments ) {
 
-		$post        = get_post( $post_id ); // Get the parent. It can be a ticket or a ticket reply
-		$max         = wpas_get_option( 'attachments_max' );
-		$id          = false; // Declare a default value for $id
-		$cnt         = 0;
-		$history_log = false;
+		$max           = wpas_get_option( 'attachments_max' );      // Core AS Max Files (File Upload settings)
+		$cnt           = 0;                                         // Initialize count of current attachments
+		$history_log   = false;                                     // No errors/rejections yet
+		$this->post_id = $post_id;                                  // Set post id for /ticket_nnnn folder creation
 
 		foreach ( $attachments as $attachment ) {
 
-			$filename = $attachment['filename'];
-			//$mimetype = $attachment['mimetype'];
-			$data = $attachment['data'];
+			$filename = $attachment['filename'];                    // Base filename
+			$data     = $attachment['data'];                        // Raw file contents
 
 			/* Limit the number of uploaded files */
 			if ( $cnt + 1 > $max ) {
@@ -704,9 +702,7 @@ class WPAS_File_Upload {
 				continue;
 			}
 
-			//$x = WPAS_File_Upload::get_instance();
-			$this->post_id = $post_id;
-
+			// Custom AS upload directory set in set_upload_dir() via upload_dir hook.
 			$upload = wp_upload_bits( $filename, null, $data );
 
 			if ( ! $upload['error'] ) {
@@ -719,7 +715,6 @@ class WPAS_File_Upload {
 					'post_content'   => '',
 					'post_status'    => 'inherit',
 				);
-
 
 				$attachment_id = wp_insert_attachment( $attachment_data, $upload['file'], $post_id );
 
@@ -736,11 +731,10 @@ class WPAS_File_Upload {
 						wp_update_attachment_metadata( $attachment_id, $attach_data );
 
 					} else {
-					$fileMeta = array(
-						'file' => $upload['file'],
-						//'wpas_upload_source' => 'email_attachment',
-					);
-					add_post_meta( $attachment_id, '_wp_attachment_metadata', $fileMeta );
+						$fileMeta = array(
+							'file' => $upload['file'],
+						);
+						add_post_meta( $attachment_id, '_wp_attachment_metadata', $fileMeta );
 
 					}
 				}

--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -730,19 +730,19 @@ class WPAS_File_Upload {
 
 				} else {
 
-					//$attach_data = wp_generate_attachment_metadata( $attachment_id, $upload['file'] );
+					$attach_data = wp_generate_attachment_metadata( $attachment_id, $upload['file'] );
 
-					//if ( ! empty( $attach_data ) ) {
-					//	wp_update_attachment_metadata( $attachment_id, $attach_data );
-//
-					//} else {
+					if ( ! empty( $attach_data ) ) {
+						wp_update_attachment_metadata( $attachment_id, $attach_data );
+
+					} else {
 					$fileMeta = array(
 						'file' => $upload['file'],
 						//'wpas_upload_source' => 'email_attachment',
 					);
 					add_post_meta( $attachment_id, '_wp_attachment_metadata', $fileMeta );
 
-					//}
+					}
 				}
 			} else {
 				$history_log[] = sprintf( __( '%s -> %s', 'wpas-gf' ), $filename, $upload['error'] );
@@ -760,7 +760,7 @@ class WPAS_File_Upload {
 				$log .= $logentry . '<br/>';
 			}
 
-			wpas_log( $this->ticket_id ? $this->ticket_id : $this->reply_id, $log );
+			wpas_log( $post_id, $log );
 		}
 
 	}

--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -701,7 +701,7 @@ class WPAS_File_Upload {
 
 			/* Limit the number of uploaded files */
 			if ( $cnt + 1 > $max ) {
-				$errors[] = sprintf( __( '%s -> Max files (%d) exceeded.', 'wpas-gf' ), $filename, $max );
+				$errors[] = sprintf( __( '%s -> Max files (%d) exceeded.', 'awesome-support' ), $filename, $max );
 				continue;
 			}
 
@@ -723,7 +723,7 @@ class WPAS_File_Upload {
 
 				if ( is_wp_error( $attachment_id ) ) {
 
-					$errors[] = sprintf( __( '%s -> %s', 'wpas-gf' ), $filename, $attachment_id->get_error_message() );
+					$errors[] = sprintf( '%s -> %s', $filename, $attachment_id->get_error_message() );
 					continue;
 
 				} else {
@@ -742,7 +742,7 @@ class WPAS_File_Upload {
 					}
 				}
 			} else {
-				$errors[] = sprintf( __( '%s -> %s', 'wpas-gf' ), $filename, $upload['error'] );
+				$errors[] = sprintf( __( '%s -> %s', 'awesome-support' ), $filename, $upload['error'] );
 			}
 
 			$cnt ++;
@@ -751,7 +751,7 @@ class WPAS_File_Upload {
 		// Log any errors
 		if ( $errors ) {
 
-			$log = __( 'Attachment Errors:', 'wpas-gf' ) . '<br />';
+			$log = __( 'Attachment Errors:', 'awesome-support' ) . '<br />';
 
 			foreach ( $errors as $error ) {
 				$log .= $error . '<br/>';

--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -742,7 +742,8 @@ class WPAS_File_Upload {
 					}
 				}
 			} else {
-				$errors[] = sprintf( __( '%s -> %s', 'awesome-support' ), $filename, $upload['error'] );
+				$errors[] = sprintf( '%s -> %s', $filename, $upload['error'] );
+
 			}
 
 			$cnt ++;

--- a/languages/awesome-support.pot
+++ b/languages/awesome-support.pot
@@ -4,14 +4,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Awesome Support 3.2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/ThemeAvenue/Awesome-Support/issues\n"
-"POT-Creation-Date: 2016-10-10 18:36+0700\n"
+"POT-Creation-Date: 2016-12-04 20:39-0600\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
 "Last-Translator: ThemeAvenue (https://themeavenue.net/)\n"
 "Language-Team: ThemeAvenue <hello@themeavenue.net>\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 1.8.11\n"
 "X-Poedit-KeywordsList: __;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;"
 "_nx_noop:1,2,3c;esc_attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;"
 "esc_html_x:1,2c\n"
@@ -280,12 +280,12 @@ msgstr ""
 msgid "Auto-Assign"
 msgstr ""
 
-#: includes/admin/functions-list-table.php:157
+#: includes/admin/functions-list-table.php:162
 #: includes/admin/metaboxes/details.php:95
 msgid "Close"
 msgstr ""
 
-#: includes/admin/functions-list-table.php:159
+#: includes/admin/functions-list-table.php:164
 #: includes/admin/metaboxes/details.php:93
 #: includes/admin/metaboxes/user-profile.php:93
 #: includes/admin/views/system-status.php:128
@@ -1537,48 +1537,62 @@ msgstr ""
 msgid "Department"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:229
+#: includes/file-uploader/class-file-uploader.php:230
 msgid "The file you requested is not a valid attachment"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:233
+#: includes/file-uploader/class-file-uploader.php:234
 msgid "The attachment you requested is not attached to any ticket"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:240
+#: includes/file-uploader/class-file-uploader.php:241
 msgid "You are not allowed to view this attachment"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:412
+#: includes/file-uploader/class-file-uploader.php:431
 msgid "Attachments"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:413
+#: includes/file-uploader/class-file-uploader.php:432
 #, php-format
 msgid ""
 " You can upload up to %d files (maximum %d MB each) of the following types: %s"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:505
+#: includes/file-uploader/class-file-uploader.php:530
 msgid "Attachments:"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:671
+#: includes/file-uploader/class-file-uploader.php:704
+#, php-format
+msgid "%s -> Max files (%d) exceeded."
+msgstr ""
+
+#: includes/file-uploader/class-file-uploader.php:745
+#, php-format
+msgid "%s -> %s"
+msgstr ""
+
+#: includes/file-uploader/class-file-uploader.php:754
+msgid "Attachment Errors:"
+msgstr ""
+
+#: includes/file-uploader/class-file-uploader.php:783
 #, php-format
 msgid ""
 "Your reply has been correctly submitted but the attachment was not uploaded. %s"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:738
+#: includes/file-uploader/class-file-uploader.php:852
 #, php-format
 msgid "You are not allowed to upload files of this type (%s)"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:742
+#: includes/file-uploader/class-file-uploader.php:856
 msgid "You cannot upload empty attachments. You attachments weights 0 bytes"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:746
+#: includes/file-uploader/class-file-uploader.php:860
 #, php-format
 msgid "Your attachment is too big. You are allowed to attach files up to %s"
 msgstr ""
@@ -1962,7 +1976,7 @@ msgstr ""
 msgid "We were unable to log you in for an unknown reason."
 msgstr ""
 
-#: includes/functions-user.php:943
+#: includes/functions-user.php:949
 #, php-format
 msgid "Did you mean %s"
 msgstr ""

--- a/languages/awesome-support.pot
+++ b/languages/awesome-support.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Awesome Support 3.2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/ThemeAvenue/Awesome-Support/issues\n"
-"POT-Creation-Date: 2016-12-04 20:39-0600\n"
+"POT-Creation-Date: 2016-12-04 20:46-0600\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1568,31 +1568,26 @@ msgstr ""
 msgid "%s -> Max files (%d) exceeded."
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:745
-#, php-format
-msgid "%s -> %s"
-msgstr ""
-
-#: includes/file-uploader/class-file-uploader.php:754
+#: includes/file-uploader/class-file-uploader.php:755
 msgid "Attachment Errors:"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:783
+#: includes/file-uploader/class-file-uploader.php:784
 #, php-format
 msgid ""
 "Your reply has been correctly submitted but the attachment was not uploaded. %s"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:852
+#: includes/file-uploader/class-file-uploader.php:853
 #, php-format
 msgid "You are not allowed to upload files of this type (%s)"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:856
+#: includes/file-uploader/class-file-uploader.php:857
 msgid "You cannot upload empty attachments. You attachments weights 0 bytes"
 msgstr ""
 
-#: includes/file-uploader/class-file-uploader.php:860
+#: includes/file-uploader/class-file-uploader.php:861
 #, php-format
 msgid "Your attachment is too big. You are allowed to attach files up to %s"
 msgstr ""


### PR DESCRIPTION
The File Upload class in core AS contains much of the logic needed to process uploads from form submissions or email attachments, but the logic was specific to the core AS Custom Field (uploads) and the My Tickets Open a Ticket.

**Example Usage:**

```
	$attachments = array();

	foreach ( $this->attachments as $attachment ) {
		$attachments[] = array(
			'filename' => $attachment['filename'],
			'data'     => file_get_contents( trailingslashit( $attachment['basedir'] ) . $attachment['filename'] ),
		);
	}
	do_action( 'wpas_process_ticket_attachments', $ticket_id, $attachments );

```
This PR provides **crucial** core support for WPAS-ES and WPAS-GF.