### PR TITLE
Unable to Delete or Update existing AS Custom Fields containing NULL

### DIFF
--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -34,7 +34,7 @@ class WPAS_Tickets_List {
 			/**
 			 * Add the taxonomies filters
 			 */
-			add_action( 'restrict_manage_posts',                array( $this, 'debug' ), 7, 2 );
+			//add_action( 'restrict_manage_posts',                array( $this, 'debug' ), 7, 2 );
 			add_action( 'restrict_manage_posts',                array( $this, 'custom_filters' ), 8, 2 );
 			add_action( 'restrict_manage_posts',                array( $this, 'custom_taxonomy_filter' ), 10, 2 );
 			add_filter( 'parse_query',                          array( $this, 'custom_taxonomy_filter_convert_id_term' ), 10, 1 );

--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -617,7 +617,8 @@ SQL;
 				'data_attr' => array( 'capability' => 'edit_ticket',
 				                      'allowClear' => true,
 				                      //'multiple'  => true,
-				                      'placeholder' => $selected, ),
+				                      'placeholder' => $selected,
+					),
 			);
 
 			if ( isset( $staff_id ) ) {
@@ -646,7 +647,10 @@ SQL;
 			'id'        => 'author',
 			'disabled'  => !current_user_can( 'assign_ticket' ) ? true : false,
 			'select2'   => true,
-			'data_attr' => array( 'capability' => 'view_ticket' ),
+			'data_attr' => array( 'capability' => 'view_ticket',
+			                      'allowClear' => true,
+				                  'placeholder' => $selected,
+				),
 		);
 
 		if ( isset( $client_id ) ) {
@@ -975,8 +979,6 @@ SQL;
 			}
 
 			//apply_filters( 'wpas_custom_column_orderby', $wp_query );
-
-			echo '<div><p>' . $GLOBALS['wp_query']->request . '</p></div>';
 
 		}
 

--- a/includes/custom-fields/class-custom-field.php
+++ b/includes/custom-fields/class-custom-field.php
@@ -783,7 +783,7 @@ class WPAS_Custom_Field {
 				 *
 				 * Action: Delete option
 				 */
-				if ( ! empty( $current ) && empty( $value ) ) {
+				if ( ( ! empty( $current ) || is_null( $current ) ) && empty( $value ) ) {
 					if ( delete_post_meta( $post_id, $field_id, $current ) ) {
 						$result = 3;
 					}
@@ -796,7 +796,7 @@ class WPAS_Custom_Field {
 				 *
 				 * Action: Update post meta OR delete it
 				 */
-				elseif ( ! empty( $current ) && ! empty( $value ) ) {
+				elseif ( ( ! empty( $current ) || is_null( $current ) ) && ! empty( $value ) ) {
 
 					/* Make sure the old and new values aren't the same */
 					if ( $current !== $value ) {


### PR DESCRIPTION
Core AS WPAS_Custom_Field::update_value() checked to see if a custom field contained a value by checking empty().  update_value() likely presumed custom field (postmeta) values would never be stored with NULL values. 

Added is_null() check on custom field value returned from postmeta.