### PR TITLE
fix: Custom save_callback for time tracking modifies $value to be sto…

### DIFF
--- a/includes/custom-fields/class-custom-field.php
+++ b/includes/custom-fields/class-custom-field.php
@@ -143,7 +143,7 @@ class WPAS_Custom_Field {
 			'update_count_callback' => 'wpas_update_ticket_tag_terms_count',
 
 			// @since 3.3.5
-			'readonly'         => false,                      // Disable user input on field.
+			'readonly'              => false,                 // Readonly field by default. Can be updated in custom save_callback
 
 		);
 
@@ -491,8 +491,9 @@ class WPAS_Custom_Field {
 			array_push( $atts, 'required' );
 		}
 
-		/* Add the disabled attribute */
+		/* Add the readonly attribute */
 		if ( isset( $this->field['args']['readonly'] ) ) {
+			/* Allow filter to change readonly setting */
 			if ( true === apply_filters('wpas_cf_field_markup_readonly', $this->field['args']['readonly'], $this->field ) ) {
 				array_push( $atts, 'readonly' );
 			}

--- a/includes/custom-fields/class-custom-fields.php
+++ b/includes/custom-fields/class-custom-fields.php
@@ -467,7 +467,7 @@ class WPAS_Custom_Fields {
 				$value  = $custom_field->get_sanitized_value( $data[ $field_form_id ] );
 				$result = $custom_field->update_value( $value, $post_id );
 
-			} else {        //if ( false === $field['args']['disable_input'] ) {
+			} else {
 				/**
 				 * This is actually important as passing an empty value
 				 * for custom fields that aren't set in the form allows
@@ -479,6 +479,11 @@ class WPAS_Custom_Fields {
 				$result = $custom_field->update_value( $value, $post_id );
 			}
 
+			/* Allow custom save_callback (if specified) to modify $value if needed */
+			if( is_array( $result ) ) {
+				$value  = $result[ 'value' ];
+				$result = $result[ 'result' ];
+			}
 
 			if ( 1 === $result || 2 === $result ) {
 				$saved[ $field['name'] ] = $value;

--- a/includes/custom-fields/functions-custom-fields.php
+++ b/includes/custom-fields/functions-custom-fields.php
@@ -512,6 +512,7 @@ function wpas_register_core_fields() {
 		'hide_front_end'	=> true,
 		'backend_only'		=> true,
 		'backend_display_type'	=> 'custom',
+		'column_callback'   => 'wpas_cf_display_time_adjustment_column',
 		'sortable_column'	=> true,
 		'title'       		=> __( 'Adjustments For Time Spent On Ticket', 'awesome-support' )
 	) );

--- a/includes/custom-fields/functions-custom-fields.php
+++ b/includes/custom-fields/functions-custom-fields.php
@@ -151,7 +151,7 @@ function wpas_add_custom_taxonomy( $name, $args = array() ) {
  * @param  string   $field_id   Field ID
  * @param  array    $field      Custom field
  *
- * @return  int         Returns result of add/update post meta
+ * @return  int|array           Returns result of add/update post meta
  */
 function wpas_update_time_spent_on_ticket( $value, $post_id, $field_id, $field ) {
 
@@ -197,27 +197,28 @@ function wpas_update_time_spent_on_ticket( $value, $post_id, $field_id, $field )
 	 */
 	$current = get_post_meta( $post_id, $field_id, true );
 
-	/* Update post meta */
-	if ( ( ! empty( $current ) || is_null( $current ) ) ) {
-		if ( false !== update_post_meta( $post_id, $field_id, $value, $current ) ) {
-			$result = 2;
+	/* Action: Update post meta */
+	if ( ( ! empty( $current ) || is_null( $current ) ) && ! empty( $value ) ) {
+		if ( $current !== $value ) {
+			if ( false !== update_post_meta( $post_id, $field_id, $value, $current ) ) {
+				$result = 2;
+			}
 		}
 	}
 
 	/* Action: Add post meta */
-	elseif ( empty( $current ) ) {
+	elseif ( empty( $current ) && ! empty( $value ) ) {
 		if ( false !== add_post_meta( $post_id, $field_id, $value, true ) ) {
 			$result = 1;
 		}
 	}
 
-	return $result;
+	return array( 'result' => $result, 'value' => $value );
 
 }
 
 
-
-	add_action( 'init', 'wpas_register_core_fields' );
+add_action( 'init', 'wpas_register_core_fields' );
 /**
  * Register the cure custom fields.
  *

--- a/includes/custom-fields/functions-custom-fields.php
+++ b/includes/custom-fields/functions-custom-fields.php
@@ -499,7 +499,7 @@ function wpas_register_core_fields() {
 		'hide_front_end'	=> true,
 		'backend_only'		=> true,
 		'backend_display_type'	=> 'custom',
-		'sortable'			=> true,
+		'sortable_column'	=> true,
 		'title'       		=> __( 'Time Spent on Ticket', 'awesome-support' )
 	) );
 
@@ -512,7 +512,7 @@ function wpas_register_core_fields() {
 		'hide_front_end'	=> true,
 		'backend_only'		=> true,
 		'backend_display_type'	=> 'custom',
-		'sortable'			=> true,		
+		'sortable_column'	=> true,
 		'title'       		=> __( 'Adjustments For Time Spent On Ticket', 'awesome-support' )
 	) );
 	
@@ -537,7 +537,7 @@ function wpas_register_core_fields() {
 		'hide_front_end'	=> true,		
 		'backend_only'		=> true,
 		'backend_display_type'	=> 'custom',
-		'sortable'			=> true,		
+		'sortable_column'	=> true,
 		'title'       		=> __( 'Final Amount Of Time Spent On Ticket', 'awesome-support' ),
 		'save_callback'     => 'wpas_update_time_spent_on_ticket',
 		'readonly'          => true,

--- a/includes/functions-templating.php
+++ b/includes/functions-templating.php
@@ -785,6 +785,29 @@ function wpas_show_assignee_column( $field, $post_id ) {
 
 }
 
+/**
+ * Display time adjustment column
+ *
+ * @param $field
+ * @param $post_id
+ */
+function wpas_cf_display_time_adjustment_column ( $field, $post_id ) {
+
+	$adjustment_time     = get_post_meta( $post_id, '_wpas_ttl_adjustments_to_time_spent_on_ticket', true );
+	$adjustment_operator = get_post_meta( $post_id, '_wpas_time_adjustments_pos_or_neg', true );
+
+	if( '+' === $adjustment_operator ) {
+
+		echo "<span style='color: #6ddb32;'>$adjustment_operator</span> <span>$adjustment_time</span>";
+
+    } elseif( '-' === $adjustment_operator ) {
+
+		echo "<span style='color: #dd3333;'>$adjustment_operator</span> (<span style='color: #dd3333;'>$adjustment_time</span>)";
+
+    }
+
+}
+
 	/**
  * Display the post status.
  *


### PR DESCRIPTION
Custom save_callback for time tracking modifies $value to be stored in postmeta depending on other time-related fields. Any change in $value was not being reflected in log entries. This fix allows for the save_callback to return an array containing both the $result and the modified $value. Array is then parsed in save_custom_fields() after call to update_value()