### PR TITLE
Multiple fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ assets/public/css/public.css
 assets/public/js/public-dist.js
 assets/public/js/public-dist.js.map
 themes/default/css/style.css
+/phpdocs/
+/docs/

--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -383,7 +383,7 @@ class WPAS_Tickets_List {
 
 					case 'date':
 					case 'status':
-					case 'assignee':
+					//case 'assignee':
 					case 'author':
 					case 'id':
 					case 'wpas-activity':
@@ -978,13 +978,24 @@ SQL;
 
 			if ( 'taxonomy' == $fields[ $orderby ][ 'args' ][ 'field_type' ] && !$fields[ $orderby ][ 'args' ][ 'taxo_std' ] ) {
 
-				$clauses[ 'join' ] .= <<<SQL
+
+				if (strpos($clauses['join'], $wpdb->term_relationships ) === false) {
+
+					$clauses[ 'join' ] .= <<<SQL
 LEFT OUTER JOIN {$wpdb->term_relationships} ON {$wpdb->posts}.ID={$wpdb->term_relationships}.object_id
 LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
 LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
 SQL;
+				}
+				else {
 
-				$clauses[ 'where' ] .= " AND (taxonomy = '" . $orderby . "' AND taxonomy IS NOT NULL)"; //OR taxonomy IS NULL)";
+					$clauses[ 'join' ] .= <<<SQL
+LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
+LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
+SQL;
+				}
+
+				$clauses[ 'where' ] .= " AND (taxonomy = '" . $orderby . "' AND taxonomy IS NOT NULL)";
 				$clauses[ 'groupby' ] = "object_id";
 				$clauses[ 'orderby' ] = "GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC) " . $order;
 

--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -38,7 +38,7 @@ class WPAS_Tickets_List {
 			add_action( 'restrict_manage_posts',                array( $this, 'custom_taxonomy_filter' ), 10, 2 );
 			add_filter( 'parse_query',                          array( $this, 'custom_taxonomy_filter_convert_id_term' ), 10, 1 );
 			add_filter( 'parse_query',                          array( $this, 'custom_meta_query' ), 11, 1 );
-			add_filter( 'posts_clauses',                        array( $this, 'post_clauses_orderby' ), 50, 2 );
+			add_filter( 'posts_clauses',                        array( $this, 'post_clauses_orderby' ), 5, 2 );
 			add_filter( 'posts_where',                          array( $this, 'posts_where' ), 10, 2 );
 			add_action( 'parse_request',                        array( $this, 'parse_request' ), 10, 1 );
 			add_action( 'pre_get_posts',                        array( $this, 'set_ordering_query_var' ), 100, 1 );
@@ -961,10 +961,10 @@ SQL;
 
 		if ( !isset( $wp_query->query[ 'post_type' ] )
 			|| $wp_query->query[ 'post_type' ] !== 'ticket'
+			|| ! $wp_query->query_vars_changed
 		) {
 			return $clauses;
 		}
-
 
 		$fields = $this->get_custom_fields();
 
@@ -978,26 +978,19 @@ SQL;
 
 			if ( 'taxonomy' == $fields[ $orderby ][ 'args' ][ 'field_type' ] && !$fields[ $orderby ][ 'args' ][ 'taxo_std' ] ) {
 
-
-				if (strpos($clauses['join'], $wpdb->term_relationships ) === false) {
-
-					$clauses[ 'join' ] .= <<<SQL
-LEFT OUTER JOIN {$wpdb->term_relationships} ON {$wpdb->posts}.ID={$wpdb->term_relationships}.object_id
-LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
-LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
+				/*
+				 *  Alias taxonomy tables used by sorting in
+				 *  case there is an active taxonomy filter. (is_tax())
+				 */
+				$clauses[ 'join' ] .= <<<SQL
+LEFT OUTER JOIN {$wpdb->term_relationships} AS t_rel ON {$wpdb->posts}.ID=t_rel.object_id
+LEFT OUTER JOIN {$wpdb->term_taxonomy} AS t_t ON t_t.term_taxonomy_id=t_rel.term_taxonomy_id
+LEFT OUTER JOIN {$wpdb->terms} AS tms ON tms.term_id=t_t.term_id
 SQL;
-				}
-				else {
 
-					$clauses[ 'join' ] .= <<<SQL
-LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
-LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
-SQL;
-				}
-
-				$clauses[ 'where' ] .= " AND (taxonomy = '" . $orderby . "' AND taxonomy IS NOT NULL)";
-				$clauses[ 'groupby' ] = "object_id";
-				$clauses[ 'orderby' ] = "GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC) " . $order;
+				$clauses[ 'where' ] .= " AND (t_t.taxonomy = '" . $orderby . "' AND t_t.taxonomy IS NOT NULL)";
+				$clauses[ 'groupby' ] = "t_rel.object_id";
+				$clauses[ 'orderby' ] = "GROUP_CONCAT(tms.name ORDER BY tms.name ASC) " . $order;
 
 			} elseif ( 'id' === $orderby ) {
 
@@ -1007,19 +1000,19 @@ SQL;
 
 			} elseif ( 'assignee' === $orderby ) {
 
-				//Join user table onto the postmeta table
-				$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->users} ag ON ( {$wpdb->prefix}postmeta.meta_key='_wpas_assignee' AND CAST({$wpdb->prefix}postmeta.meta_value AS INT)=ag.ID)";
+				// Join user table onto the postmeta table
+				$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->users} ag ON ( {$wpdb->prefix}postmeta.meta_key='_wpas_assignee' AND CAST({$wpdb->prefix}postmeta.meta_value AS UNSIGNED)=ag.ID)";
 				$clauses[ 'orderby' ] = "ag.display_name " . $order;
 
 			} elseif ( 'author' === $orderby ) {
 
-				//Join user table onto the postmeta table
+				// Join user table onto the postmeta table
 				$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->users} ON {$wpdb->prefix}posts.post_author={$wpdb->users}.ID";
 				$clauses[ 'orderby' ] = " {$wpdb->users}.display_name " . $order;
 
 			} else {
 
-				/* Exclude empty values in custom fields */
+				// Exclude empty values in custom fields
 				$clauses[ 'where' ] .= " AND TRIM(IFNULL({$wpdb->postmeta}.meta_value,''))<>'' ";
 
 			}

--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -928,15 +928,18 @@ SQL;
 	 */
 	public function posts_where( $where, $wp_query ) {
 
-		if ( is_admin()
+		if ( is_admin() && is_main_query()
+		    && ! is_null( filter_input( INPUT_GET, 'id' ) )
 			&& 'ticket' === $wp_query->query[ 'post_type' ]
 		) {
 
 			global $wpdb;
 
+			$ticket_id = filter_input( INPUT_GET, 'id', FILTER_SANITIZE_STRING );
+
 			/* Filter by Ticket ID */
-			if ( isset( $_GET[ 'id' ] ) && !empty( $_GET[ 'id' ] ) && intval( $_GET[ 'id' ] ) != 0 ) {
-				$where .= " AND {$wpdb->posts}.ID = " . intval( filter_input( INPUT_GET, 'id', FILTER_SANITIZE_STRING ) );
+			if ( ! empty( $ticket_id ) && intval( $ticket_id ) != 0 ) {
+				$where .= " AND {$wpdb->posts}.ID = " . intval( $ticket_id );
 			}
 		}
 

--- a/includes/class-product-sync.php
+++ b/includes/class-product-sync.php
@@ -531,7 +531,7 @@ class WPAS_Product_Sync {
 		foreach ( $terms as $term ) {
 
 			// If the term is a synchronized product we build the custom term object
-			if ( $this->is_synced_term( $term ) && array_key_exists( $term->name, $index ) ) {
+			if ( $this->is_synced_term( $term ) && is_array( $term ) && array_key_exists( $term->name, $index ) ) {
 				$term = $this->create_term_object( $index[ $term->name ] );
 			}
 

--- a/includes/custom-fields/class-custom-field.php
+++ b/includes/custom-fields/class-custom-field.php
@@ -95,8 +95,7 @@ class WPAS_Custom_Field {
 		/**
 		 * Get the ID of the post the custom field relates to.
 		 */
-		$this->post_id = false; // Set the default value
-		$this->post_id = isset( $post ) ? $post->ID : filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		$this->post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 
 	}
 
@@ -321,8 +320,12 @@ class WPAS_Custom_Field {
 
 		if ( empty( $value ) ) {
 
-			if ( isset( $_GET[$this->get_field_id()] ) ) {
-				$value = is_array( $_GET[$this->get_field_id()] ) ? filter_input( INPUT_GET, $this->get_field_id(), FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY ) : filter_input( INPUT_GET, $this->get_field_id(), FILTER_SANITIZE_STRING );
+			$queried_value = filter_input( INPUT_GET, $this->get_field_id(), FILTER_SANITIZE_STRING );
+
+			if ( ! empty( $queried_value ) ) {
+				$value = is_array( $_GET[$this->get_field_id()] )
+					? filter_input( INPUT_GET, $this->get_field_id(), FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY )
+					: filter_input( INPUT_GET, $this->get_field_id(), FILTER_SANITIZE_STRING );
 			}
 
 			$fields = WPAS()->session->get( 'submission_form' );
@@ -492,7 +495,7 @@ class WPAS_Custom_Field {
 		}
 
 		/* Add the readonly attribute */
-		if ( true === $this->field['args']['readonly'] ) {
+		if ( ! empty( $this->field['args']['readonly'] ) && true === $this->field['args']['readonly'] ) {
 			/* Allow filter to change readonly setting */
 			if ( true === apply_filters('wpas_cf_field_markup_readonly', $this->field['args']['readonly'], $this->field ) ) {
 				array_push( $atts, 'readonly' );

--- a/includes/custom-fields/class-custom-field.php
+++ b/includes/custom-fields/class-custom-field.php
@@ -492,7 +492,7 @@ class WPAS_Custom_Field {
 		}
 
 		/* Add the readonly attribute */
-		if ( isset( $this->field['args']['readonly'] ) ) {
+		if ( true === $this->field['args']['readonly'] ) {
 			/* Allow filter to change readonly setting */
 			if ( true === apply_filters('wpas_cf_field_markup_readonly', $this->field['args']['readonly'], $this->field ) ) {
 				array_push( $atts, 'readonly' );


### PR DESCRIPTION
fix: posts_where() running on unrelated queries.
fix: Product sync get_terms() when only term IDs are specified.
fix: Agent column sorting in tickets list.
fix: Sort and filter by taxonomy caused duplicated SQL.