### PR TITLE
fix: Product Sync name/slug displayed as term post ID

### DIFF
--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -38,7 +38,7 @@ class WPAS_Tickets_List {
 			add_action( 'restrict_manage_posts',                array( $this, 'custom_taxonomy_filter' ), 10, 2 );
 			add_filter( 'parse_query',                          array( $this, 'custom_taxonomy_filter_convert_id_term' ), 10, 1 );
 			add_filter( 'parse_query',                          array( $this, 'custom_meta_query' ), 11, 1 );
-			add_filter( 'posts_clauses',                        array( $this, 'post_clauses_orderby' ), 50, 2 );
+			add_filter( 'posts_clauses',                        array( $this, 'post_clauses_orderby' ), 5, 2 );
 			add_filter( 'posts_where',                          array( $this, 'posts_where' ), 10, 2 );
 			add_action( 'parse_request',                        array( $this, 'parse_request' ), 10, 1 );
 			add_action( 'pre_get_posts',                        array( $this, 'set_ordering_query_var' ), 100, 1 );
@@ -961,10 +961,10 @@ SQL;
 
 		if ( !isset( $wp_query->query[ 'post_type' ] )
 			|| $wp_query->query[ 'post_type' ] !== 'ticket'
+			|| ! $wp_query->query_vars_changed
 		) {
 			return $clauses;
 		}
-
 
 		$fields = $this->get_custom_fields();
 
@@ -978,26 +978,19 @@ SQL;
 
 			if ( 'taxonomy' == $fields[ $orderby ][ 'args' ][ 'field_type' ] && !$fields[ $orderby ][ 'args' ][ 'taxo_std' ] ) {
 
-
-				if (strpos($clauses['join'], $wpdb->term_relationships ) === false) {
-
-					$clauses[ 'join' ] .= <<<SQL
-LEFT OUTER JOIN {$wpdb->term_relationships} ON {$wpdb->posts}.ID={$wpdb->term_relationships}.object_id
-LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
-LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
+				/*
+				 *  Alias taxonomy tables used by sorting in
+				 *  case there is an active taxonomy filter. (is_tax())
+				 */
+				$clauses[ 'join' ] .= <<<SQL
+LEFT OUTER JOIN {$wpdb->term_relationships} AS t_rel ON {$wpdb->posts}.ID=t_rel.object_id
+LEFT OUTER JOIN {$wpdb->term_taxonomy} AS t_t ON t_t.term_taxonomy_id=t_rel.term_taxonomy_id
+LEFT OUTER JOIN {$wpdb->terms} AS tms ON tms.term_id=t_t.term_id
 SQL;
-				}
-				else {
 
-					$clauses[ 'join' ] .= <<<SQL
-LEFT OUTER JOIN {$wpdb->term_taxonomy} USING (term_taxonomy_id)
-LEFT OUTER JOIN {$wpdb->terms} USING (term_id)
-SQL;
-				}
-
-				$clauses[ 'where' ] .= " AND (taxonomy = '" . $orderby . "' AND taxonomy IS NOT NULL)";
-				$clauses[ 'groupby' ] = "object_id";
-				$clauses[ 'orderby' ] = "GROUP_CONCAT({$wpdb->terms}.name ORDER BY name ASC) " . $order;
+				$clauses[ 'where' ] .= " AND (t_t.taxonomy = '" . $orderby . "' AND t_t.taxonomy IS NOT NULL)";
+				$clauses[ 'groupby' ] = "t_rel.object_id";
+				$clauses[ 'orderby' ] = "GROUP_CONCAT(tms.name ORDER BY tms.name ASC) " . $order;
 
 			} elseif ( 'id' === $orderby ) {
 
@@ -1007,19 +1000,19 @@ SQL;
 
 			} elseif ( 'assignee' === $orderby ) {
 
-				//Join user table onto the postmeta table
-				$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->users} ag ON ( {$wpdb->prefix}postmeta.meta_key='_wpas_assignee' AND CAST({$wpdb->prefix}postmeta.meta_value AS INT)=ag.ID)";
+				// Join user table onto the postmeta table
+				$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->users} ag ON ( {$wpdb->prefix}postmeta.meta_key='_wpas_assignee' AND CAST({$wpdb->prefix}postmeta.meta_value AS UNSIGNED)=ag.ID)";
 				$clauses[ 'orderby' ] = "ag.display_name " . $order;
 
 			} elseif ( 'author' === $orderby ) {
 
-				//Join user table onto the postmeta table
+				// Join user table onto the postmeta table
 				$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->users} ON {$wpdb->prefix}posts.post_author={$wpdb->users}.ID";
 				$clauses[ 'orderby' ] = " {$wpdb->users}.display_name " . $order;
 
 			} else {
 
-				/* Exclude empty values in custom fields */
+				// Exclude empty values in custom fields
 				$clauses[ 'where' ] .= " AND TRIM(IFNULL({$wpdb->postmeta}.meta_value,''))<>'' ";
 
 			}

--- a/includes/class-product-sync.php
+++ b/includes/class-product-sync.php
@@ -531,8 +531,8 @@ class WPAS_Product_Sync {
 		foreach ( $terms as $term ) {
 
 			// If the term is a synchronized product we build the custom term object
-			if ( $this->is_synced_term( $term ) && is_array( $term ) && array_key_exists( $term->name, $index ) ) {
-				$term = $this->create_term_object( $index[ $term->name ] );
+			if ( $this->is_synced_term( $term->term_id ) && array_key_exists( (int) $term->name, $index ) ) {
+				$term = $this->create_term_object( $index[ (int) $term->name ] );
 			}
 
 			if ( false !== $term ) {

--- a/includes/class-product-sync.php
+++ b/includes/class-product-sync.php
@@ -521,19 +521,28 @@ class WPAS_Product_Sync {
 		foreach ( $query->posts as $post ) {
 			if( isset( $post->ID ) ) {
 				$index[ $post->ID ] = $post;
-			}
+			} else {
+			    $index[ $post ] = $post;
+            }
 		}
 
 		// We will store the new terms in this array
 		$new_terms = array();
 
 		// Now go go through each term, maybe update it, and add it to the final terms array
-		foreach ( $terms as $term ) {
+		foreach ( $terms as $key => $term ) {
 
-			// If the term is a synchronized product we build the custom term object
-			if ( $this->is_synced_term( $term->term_id ) && array_key_exists( (int) $term->name, $index ) ) {
-				$term = $this->create_term_object( $index[ (int) $term->name ] );
-			}
+		    // If the term is a synchronized product we build the custom term object
+		    if ( $this->is_synced_term( $term ) ) {
+
+			    $tid = is_a( $term, 'WP_Term' ) ? (int) $term->name : (int) $term;
+
+                // Create the custom term object
+                if( array_key_exists( (int) $tid, $index ) ) {
+	                $term = $this->create_term_object( $index[ $tid ] );
+                }
+
+		    }
 
 			if ( false !== $term ) {
 				$new_terms[] = apply_filters( 'wpas_get_terms_term', $term, $this->taxonomy );

--- a/includes/custom-fields/field-types/class-cf-checkbox.php
+++ b/includes/custom-fields/field-types/class-cf-checkbox.php
@@ -13,41 +13,8 @@ class WPAS_CF_Checkbox extends WPAS_Custom_Field {
 		// Call parent constructor
 		parent::__construct( $field_id, $field );
 
-		// Checkboxes need a custom wrapper class
-		add_filter( 'wpas_cf_wrapper_class', array( $this, 'wrapper_class' ), 10, 2 );
-
 	}
 
-	/**
-	 * Add a specific wrapper class for checkboxes and remove the default one
-	 *
-	 * @since 3.3
-	 *
-	 * @param array $classes Wrapper classes
-	 * @param array $field   Field data
-	 *
-	 * @return array
-	 */
-	public function wrapper_class( $classes, $field ) {
-
-		if ( 'checkbox' !== $field['args']['field_type'] ) {
-			return $classes;
-		}
-
-		// Remove the default wrapper class if it's here
-		$key = array_search( 'wpas-form-group', $classes );
-
-		if ( false !== $key ) {
-			unset( $classes[ $key ] );
-		}
-
-		if ( ! in_array( 'wpas-checkbox', $classes ) ) {
-			$classes[] = 'wpas-checkbox';
-		}
-
-		return $classes;
-
-	}
 
 	/**
 	 * Return the field markup for the front-end.

--- a/includes/custom-fields/field-types/class-cf-radio.php
+++ b/includes/custom-fields/field-types/class-cf-radio.php
@@ -19,7 +19,7 @@ class WPAS_CF_Radio extends WPAS_Custom_Field {
 			return '<!-- No options declared -->';
 		}
 
-		$output        = '<legend class="wpas-label-radio">{{label}}</legend>';
+		$output        = '<label class="wpas-label-radio">{{label}}</label>';
 		$this->options = $this->field_args['options'];
 
 		// Radio buttons cannot be set to readonly. (A missing HTML spec??) To overcome this
@@ -28,7 +28,7 @@ class WPAS_CF_Radio extends WPAS_Custom_Field {
 
 		foreach ( $this->options as $option_id => $option_label ) {
 			$selected = $option_id === $this->populate() ? 'checked' : $readonly;
-			$output .= sprintf( "<div class='wpas-radio'><label><input type='radio' name='%s' value='%s' %s > %s</label></div>", $this->get_field_id(), $option_id, $selected, $option_label );
+			$output .= sprintf( "<div class='wpas-radio'><span><input type='radio' name='%s' value='%s' %s > %s</span></div>", $this->get_field_id(), $option_id, $selected, $option_label );
 		}
 
 		return $output;

--- a/themes/default/less/style.less
+++ b/themes/default/less/style.less
@@ -87,14 +87,13 @@ Forms + Buttons + Labels
 .wpas-form-group {
 	margin-bottom: @spacing;
 }
-.wpas-checkbox + .wpas-checkbox {
-	margin-bottom: @spacing;
+.wpas-checkbox {
 	label {
 		font-weight: normal;
 	}
 }
 .wpas-form-group {
-	label {
+	> label {
 		display: inline-block;
 		max-width: 100%;
 		margin-bottom: @spacing/3;


### PR DESCRIPTION
Strange issue that I thought was fixed once. I didn't fully understand the Product Sync logic. It appears that a Product taxonomy term is saved with name and slug as the post ID of the term. These name and slug values are set to the term's post_title and post_name properties.

The problem was in get_terms() where product terms were not being detected as synced WooCommerce products.

I think the problem was strictly aesthetic and no harm was done to any data.