### PR TITLE
FUNCTION_EXISTS( $CALLBACK ) => DISABLES CLASS DECLARATION Ticket #81…

### DIFF
--- a/includes/functions-templating.php
+++ b/includes/functions-templating.php
@@ -667,8 +667,8 @@ function wpas_get_tickets_list_column_content( $column_id, $column ) {
 
 		default:
 
-			if ( function_exists( $callback ) ) {
-				call_user_func( $callback, $column_id, get_the_ID() );
+			if ( ( is_array( $callback ) && method_exists( $callback[0], $callback[1] ) ) || ( ! is_array( $callback ) && function_exists( $callback ) ) ) {
+   				call_user_func( $callback, $column_id, get_the_ID() );
 			}
 
 		break;


### PR DESCRIPTION
…6194

Hi,

I am working on a custom theme for my awesome support helpdesk but I encounter an error.

I am adding columns to the ticket list using:

$columns['project_reference'] = [
   'title'    => __t( 'Reference' ),
   'callback' => [$this, 'get_ticket_list_project_reference']
];

However this fails because of the function_exists:

PHP Warning:  function_exists() expects parameter 1 to be string, array given in/wp-content/plugins/awesome-support/includes/functions-templating.php on line 662

Please change the code to the following so it also accepts call_user_func from an object:

if ( ( is_array( $callback ) && method_exists( $callback[0], $callback[1] ) ) || ( ! is_array( $callback ) && function_exists( $callback ) ) ) {
   call_user_func( $callback, $column_id, get_the_ID() );
}

Thanks, please let me know when i can expect the update!