### PR TITLE
add: Delete Unused Product Terms tool to Tools menu. Tool obtains a l…

### DIFF
--- a/includes/class-product-sync.php
+++ b/includes/class-product-sync.php
@@ -101,18 +101,19 @@ class WPAS_Product_Sync {
 				$this->run_initial_sync();
 			}
 
-			add_filter( 'get_terms',                        array( $this, 'get_terms' ),          1, 3 );
-			add_filter( 'get_term',                         array( $this, 'get_term' ),           1, 2 );
-			add_filter( 'get_the_terms',                    array( $this, 'get_the_terms' ),      1, 3 );
-			add_action( 'init',                             array( $this, 'lock_taxonomy' ),     12, 0 );
-			add_action( 'admin_notices',                    array( $this, 'notice_locked_tax' ), 10, 0 );
+			add_filter( 'get_terms',                        array( $this, 'get_terms' ),                       1, 3 );
+			add_filter( 'get_term',                         array( $this, 'get_term' ),                        1, 2 );
+			add_filter( 'get_the_terms',                    array( $this, 'get_the_terms' ),                   1, 3 );
+			add_action( 'init',                             array( $this, 'lock_taxonomy' ),                  12, 0 );
+			add_action( 'admin_notices',                    array( $this, 'notice_locked_tax' ),              10, 0 );
 
-			add_action( 'wp_insert_post',                   array( $this, 'sync_term' ),         10, 3 );
-			add_action( 'trashed_post',                     array( $this, 'unsync_term' ),       10, 1 );
-			add_action( 'delete_post',                      array( $this, 'unsync_term' ),       10, 1 );
+			add_action( 'wp_insert_post',                   array( $this, 'sync_term' ),                      10, 3 );
+			add_action( 'trashed_post',                     array( $this, 'unsync_term' ),                    10, 1 );
+			add_action( 'delete_post',                      array( $this, 'unsync_term' ),                    10, 1 );
 
-			add_action( 'wpas_system_tools_table_after',    array( $this, 'add_resync_tool' ),   10, 0 );
-			add_action( 'wpas_system_tools_table_after',    array( $this, 'add_delete_tool' ),   10, 0 );
+			add_action( 'wpas_system_tools_table_after',    array( $this, 'add_resync_tool' ),                11, 0 );
+			add_action( 'wpas_system_tools_table_after',    array( $this, 'add_delete_tool' ),                12, 0 );
+			add_action( 'wpas_system_tools_table_after',    array( $this, 'add_delete_unused_terms_tool' ),   13, 0 );
 
 		}
 
@@ -962,6 +963,23 @@ class WPAS_Product_Sync {
 				   class="button-secondary"><?php _e( 'Delete', 'awesome-support' ); ?></a>
 				<span
 					class="wpas-system-tools-desc"><?php _e( 'Delete all products synchronized from your e-commerce plugin.', 'awesome-support' ); ?></span>
+			</td>
+		</tr>
+	<?php }
+
+	/**
+	 * Adds a button to delete unused Product Terms system tools.
+	 *
+	 * @since 3.1.7
+	 */
+	public function add_delete_unused_terms_tool() { ?>
+		<tr>
+			<td class="row-title"><label for="tablecell"><?php _e( 'Delete unused Product Terms', 'awesome-support' ); ?></label></td>
+			<td>
+				<a href="<?php echo wpas_tool_link( 'delete_unused_terms', array( 'pt' => $this->post_type ) ); ?>"
+				   class="button-secondary"><?php _e( 'Delete', 'awesome-support' ); ?></a>
+				<span
+					class="wpas-system-tools-desc"><?php _e( 'Delete all Product Terms not used in any AS ticket.', 'awesome-support' ); ?></span>
 			</td>
 		</tr>
 	<?php }


### PR DESCRIPTION
…ist of all Product taxonomy terms and then checks to see if any ticket post type contains a relationship to the term. If no posts use the term it is deleted from the taxonomy. Regardless of whether the term is deleted or not its count is updated.