### PR TITLE
fix: Previous Titan Framework fix addressed a performance issue repor…

### DIFF
--- a/includes/admin/class-admin-titan.php
+++ b/includes/admin/class-admin-titan.php
@@ -95,12 +95,6 @@ class WPAS_Titan {
 				)
 		);
 
-		if( ! isset( $_GET['page'] ) || 'wpas-settings' !== $_GET['page']
-		    || ! wpas_is_plugin_page()
-		) {
-			return;
-		}
-
 		/**
 		 * Get plugin core options
 		 * 

--- a/includes/admin/settings/settings-products-management.php
+++ b/includes/admin/settings/settings-products-management.php
@@ -75,6 +75,9 @@ function wpas_get_products_options() {
 
 		$registered = WPAS_eCommerce_Integration::get_instance()->get_plugins();
 		$post_type  = $registered[ $ecommerce_synced ]['post_type'];
+		$options    = ( isset( $_GET['page'] ) && 'wpas-settings' === $_GET['page'] && wpas_is_plugin_page() )
+			? wpas_list_pages( $post_type )
+			: '';
 
 		$products[] = array(
 			'name'     => __( 'Include Products', 'awesome-support' ),
@@ -82,7 +85,7 @@ function wpas_get_products_options() {
 			'type'     => 'select',
 			'multiple' => true,
 			'desc'     => esc_html__( 'Which products do you want to synchronize with Awesome Support (leave blank for all products)', 'awesome-support' ),
-			'options'  => wpas_list_pages( $post_type ),
+			'options'  => $options,
 			'default'  => ''
 		);
 
@@ -92,7 +95,7 @@ function wpas_get_products_options() {
 			'type'     => 'select',
 			'multiple' => true,
 			'desc'     => esc_html__( 'Which products do you want to exclude from synchronization with Awesome Support (leave blank for no exclusion)', 'awesome-support' ),
-			'options'  => wpas_list_pages( $post_type ),
+			'options'  => $options,
 			'default'  => ''
 		);
 


### PR DESCRIPTION
…ted when there are a large number of WC products and product sync is enabled. This problem could arise on tabs other than Product Management, but in this case we are trying to populate a multiple select field with 30,000 items - plus doing it twice. Once for includes and once for excludes. This commit moves logic to the settings-product-management.php code. Specifically for the wpas_list_pages() call.