### PR TITLE
Cache admin menu ticket count

### DIFF
--- a/includes/functions-email-notifications.php
+++ b/includes/functions-email-notifications.php
@@ -44,6 +44,7 @@ add_action( 'wpas_open_ticket_after', 'wpas_notify_assignment', 12, 2 );
  */
 function wpas_notify_assignment( $ticket_id, $agent_id ) {
 	wpas_email_notify( $ticket_id, 'new_ticket_assigned' );
+	delete_transient( 'wpas_tickets_counts' );
 }
 
 add_action( 'wpas_ticket_after_update_admin_success', 'wpas_notify_admin_assignment', 12, 3 );

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -321,6 +321,13 @@ function wpas_insert_ticket( $data = array(), $post_id = false, $agent_id = fals
 	/* Set the ticket as open. */
 	add_post_meta( $ticket_id, '_wpas_status', 'open', true );
 
+	/* . */
+	add_post_meta( $ticket_id, '_wpas_last_reply_date', null, true );
+	add_post_meta( $ticket_id, '_wpas_last_reply_date_gmt', null, true );
+
+	/* . */
+	add_post_meta( $ticket_id, '_wpas_is_waiting_client_reply', ! user_can( $data['post_author'], 'edit_ticket' ), true  );
+
 	if ( false === $agent_id ) {
 		$agent_id = wpas_find_agent( $ticket_id );
 	}
@@ -1014,6 +1021,12 @@ function wpas_insert_reply( $data, $post_id = false ) {
 	 * Fire wpas_add_reply_complete after the reply and attachments was successfully added.
 	 */
 	do_action( 'wpas_add_reply_complete', $reply_id, $data );
+
+	/* . */
+	update_post_meta( $data[ 'post_parent' ], '_wpas_last_reply_date', current_time( 'mysql' ) );
+	update_post_meta( $data[ 'post_parent' ], '_wpas_last_reply_date_gmt', current_time( 'mysql', 1 ) );
+
+	update_post_meta( $data[ 'post_parent' ], '_wpas_is_waiting_client_reply', ! current_user_can( 'edit_ticket' )  );
 
 	return $reply_id;
 

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -321,13 +321,6 @@ function wpas_insert_ticket( $data = array(), $post_id = false, $agent_id = fals
 	/* Set the ticket as open. */
 	add_post_meta( $ticket_id, '_wpas_status', 'open', true );
 
-	/* . */
-	add_post_meta( $ticket_id, '_wpas_last_reply_date', null, true );
-	add_post_meta( $ticket_id, '_wpas_last_reply_date_gmt', null, true );
-
-	/* . */
-	add_post_meta( $ticket_id, '_wpas_is_waiting_client_reply', ! user_can( $data['post_author'], 'edit_ticket' ), true  );
-
 	if ( false === $agent_id ) {
 		$agent_id = wpas_find_agent( $ticket_id );
 	}
@@ -1021,12 +1014,6 @@ function wpas_insert_reply( $data, $post_id = false ) {
 	 * Fire wpas_add_reply_complete after the reply and attachments was successfully added.
 	 */
 	do_action( 'wpas_add_reply_complete', $reply_id, $data );
-
-	/* . */
-	update_post_meta( $data[ 'post_parent' ], '_wpas_last_reply_date', current_time( 'mysql' ) );
-	update_post_meta( $data[ 'post_parent' ], '_wpas_last_reply_date_gmt', current_time( 'mysql', 1 ) );
-
-	update_post_meta( $data[ 'post_parent' ], '_wpas_is_waiting_client_reply', ! current_user_can( 'edit_ticket' )  );
 
 	return $reply_id;
 


### PR DESCRIPTION
Hi,

I did a function profile of my site and found that `wpas_tickets_count` slows down the backend (with 1k tickets):

```
hookFunc                                                           time
init#wp_cron                                                     1010.12 ms
shutdown#QM_Dispatcher_Html->dispatch                             497.72 ms
admin_menu#wpas_tickets_count                                     129.16 ms
shutdown#wp_ob_end_flush_all                                      118.29 ms
shutdown#wp_session_write_close                                    97.67 ms
....
````

This PR caches the ticket count for each user in a transient. Note the I'm not using `wp_cache_*`, because the object cache is not persitent accross requests by default.

The transient is deleted on `wpas_open_ticket_after` in `wpas_notify_assignment`.  Let me know if there is a better place. 