### PR TITLE
add clickable labels to radio options - attempt 2

### DIFF
--- a/assets/admin/less/admin.less
+++ b/assets/admin/less/admin.less
@@ -430,9 +430,6 @@ Metaboxes - Custom Fields
 		display: block;
 		margin-bottom: .25em;
 	}
-    .wpas-radio label {
-        display:inline-block;   
-    }
 }
 
 

--- a/assets/admin/less/admin.less
+++ b/assets/admin/less/admin.less
@@ -430,6 +430,9 @@ Metaboxes - Custom Fields
 		display: block;
 		margin-bottom: .25em;
 	}
+    .wpas-radio label {
+        display:inline-block;   
+    }
 }
 
 

--- a/assets/admin/less/admin.less
+++ b/assets/admin/less/admin.less
@@ -430,6 +430,9 @@ Metaboxes - Custom Fields
 		display: block;
 		margin-bottom: .25em;
 	}
+    .wpas-radio label {
+        display:inline-block;
+    }
 }
 
 

--- a/includes/custom-fields/field-types/class-cf-radio.php
+++ b/includes/custom-fields/field-types/class-cf-radio.php
@@ -26,10 +26,12 @@ class WPAS_CF_Radio extends WPAS_Custom_Field {
 		// we set the selected radio button option to 'checked' and all others to 'disabled'.
 		$readonly = wpas_cf_field_markup_time_tracking_readonly( $this->get_field_arg( 'readonly', false ), $this->field ) ? 'disabled' : '';
 
-		foreach ( $this->options as $option_id => $option_label ) {
-			$selected = $option_id === $this->populate() ? 'checked' : $readonly;
-			$output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-%2$s" value="%2$s" %3$s > <label for="%1$s-%2$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label );
-		}
+        $index = 1;
+        foreach ( $this->options as $option_id => $option_label ) {
+            $selected = $option_id === $this->populate() ? 'checked' : $readonly;
+            $output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-option%5$s" value="%2$s" %3$s > <label for="%1$s-option%5$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label, $index );
+            $index++;
+        }
 
 		return $output;
 

--- a/includes/custom-fields/field-types/class-cf-radio.php
+++ b/includes/custom-fields/field-types/class-cf-radio.php
@@ -26,11 +26,9 @@ class WPAS_CF_Radio extends WPAS_Custom_Field {
 		// we set the selected radio button option to 'checked' and all others to 'disabled'.
 		$readonly = wpas_cf_field_markup_time_tracking_readonly( $this->get_field_arg( 'readonly', false ), $this->field ) ? 'disabled' : '';
 
-        $index = 1;
 		foreach ( $this->options as $option_id => $option_label ) {
 			$selected = $option_id === $this->populate() ? 'checked' : $readonly;
-			$output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-option%5$s" value="%2$s" %3$s > <label for="%1$s-option%5$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label, $index );
-			$index++;
+			$output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-%2$s" value="%2$s" %3$s > <label for="%1$s-%2$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label );
 		}
 
 		return $output;

--- a/includes/custom-fields/field-types/class-cf-radio.php
+++ b/includes/custom-fields/field-types/class-cf-radio.php
@@ -28,7 +28,7 @@ class WPAS_CF_Radio extends WPAS_Custom_Field {
 
 		foreach ( $this->options as $option_id => $option_label ) {
 			$selected = $option_id === $this->populate() ? 'checked' : $readonly;
-			$output .= sprintf( "<div class='wpas-radio'><span><input type='radio' name='%s' value='%s' %s > %s</span></div>", $this->get_field_id(), $option_id, $selected, $option_label );
+			$output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-%2$s" value="%2$s" %3$s > <label for="%1$s-%2$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label );
 		}
 
 		return $output;

--- a/includes/custom-fields/field-types/class-cf-radio.php
+++ b/includes/custom-fields/field-types/class-cf-radio.php
@@ -26,9 +26,11 @@ class WPAS_CF_Radio extends WPAS_Custom_Field {
 		// we set the selected radio button option to 'checked' and all others to 'disabled'.
 		$readonly = wpas_cf_field_markup_time_tracking_readonly( $this->get_field_arg( 'readonly', false ), $this->field ) ? 'disabled' : '';
 
+        $index = 1;
 		foreach ( $this->options as $option_id => $option_label ) {
 			$selected = $option_id === $this->populate() ? 'checked' : $readonly;
-			$output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-%2$s" value="%2$s" %3$s > <label for="%1$s-%2$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label );
+			$output .= sprintf( '<div class="wpas-radio"><span><input type="radio" name="%1$s" id="%1$s-option%5$s" value="%2$s" %3$s > <label for="%1$s-option%5$s">%4$s</label></span></div>', $this->get_field_id(), $option_id, $selected, $option_label, $index );
+			$index++;
 		}
 
 		return $output;


### PR DESCRIPTION
- changed "id" attribute to not use $option_id which may contain spaces, added a counter instead
- updated admin.less to display back-end radio labels as inline-block. The line will still break if the text is long, but I don't think that's a bad thing
- not sure why indentation looks weird