### PR TITLE
Wizard menu: Hide from admin menu

### DIFF
--- a/assets/admin/css/wizard-notice.css
+++ b/assets/admin/css/wizard-notice.css
@@ -8,3 +8,6 @@
 	font-size: 14px;
 	font-weight: bolder;
 }
+#menu-dashboard .wp-submenu.wp-submenu-wrap li a[href="as-setup"]{
+	display: none;
+}


### PR DESCRIPTION
Force hide 'Setup Wizard' menu from appearing in WP menu