### PR TITLE
Fixed display of user role when array is not zero based.

### DIFF
--- a/includes/admin/metaboxes/replies-published.php
+++ b/includes/admin/metaboxes/replies-published.php
@@ -41,7 +41,7 @@ if ( ! defined( 'WPINC' ) ) {
 	<?php $show_extended_date_in_replies = boolval( wpas_get_option( 'show_extended_date_in_replies', false ) ); ?>
 	<div class="wpas-reply-meta">
 		<div class="wpas-reply-user">
-			<strong class="wpas-profilename"><?php echo $user_name; ?></strong><?php if ( $user_data ): ?> <span class="wpas-profilerole">(<?php echo wpas_get_user_nice_role( $user_data->roles[0] ); ?>)</span><?php endif; ?>
+			<strong class="wpas-profilename"><?php echo $user_name; ?></strong><?php if ( $user_data ): ?> <span class="wpas-profilerole">(<?php echo wpas_get_user_nice_role( $user_data->roles ); ?>)</span><?php endif; ?>
 		</div>
 		<div class="wpas-reply-time">
 			<time class="wpas-timestamp" datetime="<?php echo get_the_date( 'Y-m-d\TH:i:s' ) . wpas_get_offset_html5(); ?>"><span class="wpas-human-date"><?php echo date( get_option( 'date_format' ), strtotime( $row->post_date ) ); ?> <?php if ( true === $show_extended_date_in_replies ) { printf( __( '(%s - %s since ticket was opened.)', 'awesome-support' ), $date_full, $days_since_open ); } ?>  | </span><?php printf( __( '%s ago', 'awesome-support' ), $date ); ?></time>

--- a/includes/functions-user.php
+++ b/includes/functions-user.php
@@ -671,7 +671,11 @@ function wpas_can_reply_ticket( $admins_allowed = false, $post_id = null ) {
  * @return string       Nicely formatted user role
  */
 function wpas_get_user_nice_role( $role ) {
-
+	/* Get first role if role is an array */
+	if ( is_array($role) ) {
+		$role = array_shift( array_values($role) );
+	}
+	
 	/* Remove the prefix on WPAS roles */
 	if ( 'wpas_' === substr( $role, 0, 5 ) ) {
 		$role = substr( $role, 5 );

--- a/themes/default/partials/ticket-origin.php
+++ b/themes/default/partials/ticket-origin.php
@@ -50,7 +50,7 @@ do_action( 'wpas_before_original_post' ); ?>
 						 * Display the ticket's author name (client's name)
 						 */
 						?><span class="wpas-profilename"><?php echo $author->data->user_nicename; ?></span> 
-						<span class="wpas-profiletype"><?php echo wpas_get_user_nice_role( $author->roles[0] ); ?></span> 
+						<span class="wpas-profiletype"><?php echo wpas_get_user_nice_role( $author->roles ); ?></span> 
 						<time class="visible-xs wpas-timestamp" datetime="<?php echo str_replace( ' ', 'T', $post->post_date ); ?>Z">
 							<?php printf( __( '%s ago', 'awesome-support' ), human_time_diff( get_the_time( 'U', $post->ID ), current_time( 'timestamp' ) ) ); ?>
 						</time>


### PR DESCRIPTION
The user roles that would be returned from $user_data->roles where something like:

`{ [2] => 'Editor', [3] => 'Administrator' }`

I'm not sure if this is due to the user role editor plugin that we are using called 'User Role Editor'. Also the private notes plugin needs to be updated too:

class-private-note.php @ line 398:

`<?php echo wpas_get_user_nice_role( $user_data->roles ); ?>`
