### PR TITLE
Productivity plugin editor settings not being applied to edit ticket editor

### DIFF
--- a/assets/admin/js/admin-edit-ticket-content.js
+++ b/assets/admin/js/admin-edit-ticket-content.js
@@ -85,7 +85,7 @@
                         if(response.content){
                             $('.wpas-main-ticket-message').html(response.content);
                         }
-                    }                    
+                    } 
                 });
 
             });
@@ -154,10 +154,40 @@
             var settings = {
                 mediaButtons:	false,
                 tinymce:	{
-                    toolbar1: 'bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,strikethrough,hr,forecolor,pastetext,removeformat,codeformat,undo,redo'
+                    toolbar:	[]
                 },
-                quicktags:		true,
+                quicktags:		true
             };
+
+            /**
+             * Copy settings from reply editor
+            */
+            var replyEditor = tinyMCE.get("wpas_reply");
+            if ((replyEditor != null) && (replyEditor.hasOwnProperty("settings"))) {
+                if (replyEditor.settings.hasOwnProperty("toolbar1")) {
+                    settings.tinymce.toolbar.push(replyEditor.settings.toolbar1);
+                }
+                if (replyEditor.settings.hasOwnProperty("toolbar2")) {
+                    settings.tinymce.toolbar.push(replyEditor.settings.toolbar2);
+                }
+                if (replyEditor.settings.hasOwnProperty("toolbar3")) {
+                    settings.tinymce.toolbar.push(replyEditor.settings.toolbar3);
+                }
+                if (replyEditor.settings.hasOwnProperty("toolbar4")) {
+                    settings.tinymce.toolbar.push(replyEditor.settings.toolbar4);
+                }
+                if (replyEditor.settings.hasOwnProperty("plugins")) {
+                    settings.tinymce.plugins = replyEditor.settings.plugins;
+                }
+                if (replyEditor.settings.hasOwnProperty("wordpress_adv_hidden")) {
+                    settings.tinymce.wordpress_adv_hidden = replyEditor.settings.wordpress_adv_hidden;
+                }
+            }
+
+            if (settings.tinymce.toolbar.length == 0) {
+                settings.tinymce.toolbar.push('bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,strikethrough,hr,forecolor,pastetext,removeformat,codeformat,undo,redo');
+            }
+
             /**
              * Initialize editor
             */


### PR DESCRIPTION
I submitted a support request about this already, but here I believe is the fix. It copies the settings from the reply editor on the same page for initializing the edit ticket editor.

The problem is when having the productivity pack installed and having Use Teeny Editor as Disabled.

![teenyoption](https://user-images.githubusercontent.com/1364432/42392003-2087fc9e-8106-11e8-8fdf-987703d077ce.PNG)

Then clicking on the Edit button for the ticket:

![editbutton](https://user-images.githubusercontent.com/1364432/42391997-1c97dd8e-8106-11e8-9b03-05e183b75f2e.png)

Shows this "minimial" editor instead of the full editor that is expected:

![teenyeditor](https://user-images.githubusercontent.com/1364432/42391998-1cb19562-8106-11e8-9e46-3c46761fe57e.PNG)
