### PR TITLE
Support for private notes in WPAS_Email_Notification

### DIFF
--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -44,7 +44,11 @@ class WPAS_Email_Notification {
 	public function __construct( $post_id ) {
 
 		/* Make sure the given post belongs to our plugin. */
-		if ( !in_array( get_post_type( $post_id ), array( 'ticket', 'ticket_reply', 'ticket_note' ) ) ) {
+
+		$post_types = 
+			apply_filters( 'wpas_email_notifications_post_types', array( 'ticket', 'ticket_reply' ) );
+
+		if ( !in_array( get_post_type( $post_id ), $post_types ) ) {
 			return new WP_Error( 'incorrect_post_type', __( 'The post ID provided does not match any of the plugin post types', 'awesome-support' ) );
 		}
 

--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -327,6 +327,22 @@ class WPAS_Email_Notification {
 				'desc' 	=> __( 'Converts into client e-mail address', 'awesome-support' )
 			),
 			array(
+				'tag' 	=> '{author_name}',
+				'desc' 	=> __( 'Converts into author name (WordPress Display Name)', 'awesome-support' )
+			),
+			array(
+				'tag' 	=> '{author_first_name}',
+				'desc' 	=> __( 'Converts into the first name of the author', 'awesome-support' )
+			),
+			array(
+				'tag' 	=> '{author_last_name}',
+				'desc' 	=> __( 'Converts into the last name of the author', 'awesome-support' )
+			),			
+			array(
+				'tag' 	=> '{author_email}',
+				'desc' 	=> __( 'Converts into author e-mail address', 'awesome-support' )
+			),
+			array(
 				'tag' 	=> '{ticket_title}',
 				'desc' 	=> __( 'Converts into current ticket title', 'awesome-support' )
 			),
@@ -385,17 +401,11 @@ class WPAS_Email_Notification {
 		if ( empty( $agent_id ) ) {
 			$agent_id = wpas_get_option( 'assignee_default', 1 );
 		}
-		
-		// If reply check if from agent
-		if ($this->ticket_id !== $this->post_id) {
-			$author_id = $this->get_reply()->post_author;
-			if ( user_can($author_id, 'edit_ticket') ) {
-				$agent_id = $author_id;
-			}
-		}
 
 		$agent  = get_user_by( 'id', (int) $agent_id  );
 		$client = get_user_by( 'id', $this->get_ticket()->post_author );
+		$author = get_user_by( 'id', $this->ticket_id === $this->post_id ? 
+			$this->get_ticket()->post_author : $this->get_reply()->post_author);
 
 		/* Get the ticket links */
 		$url_public  = get_permalink( $this->get_ticket()->ID );
@@ -450,6 +460,22 @@ class WPAS_Email_Notification {
 					
 				case 'client_email':
 					$tag['value'] = !empty($client) ? $client->user_email : '';
+					break;
+
+				case 'author_name':
+					$tag['value'] = !empty($author) ? $author->display_name : '';
+					break;
+					
+				case 'author_first_name':
+					$tag['value'] = !empty($author) ? $author->first_name : '';
+					break;					
+				
+				case 'author_last_name':
+					$tag['value'] = !empty($author) ? $author->last_name : '';
+					break;
+					
+				case 'author_email':
+					$tag['value'] = !empty($author) ? $author->user_email : '';
 					break;
 
 				case 'ticket_title':

--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -45,8 +45,7 @@ class WPAS_Email_Notification {
 
 		/* Make sure the given post belongs to our plugin. */
 
-		$post_types = 
-			apply_filters( 'wpas_email_notifications_post_types', array( 'ticket', 'ticket_reply' ) );
+		$post_types = apply_filters( 'wpas_email_notifications_post_types', array( 'ticket', 'ticket_reply' ) );
 
 		if ( !in_array( get_post_type( $post_id ), $post_types ) ) {
 			return new WP_Error( 'incorrect_post_type', __( 'The post ID provided does not match any of the plugin post types', 'awesome-support' ) );
@@ -94,8 +93,9 @@ class WPAS_Email_Notification {
 			return $this->reply;
 		}
 
-		if ( 'ticket_reply' !== get_post_type( $this->post_id ) &&
-		     'ticket_note' !== get_post_type($this->post_id) ) {
+		$reply_types = apply_filters( 'wpas_email_notifications_reply_types', array( 'ticket_reply' ) );
+
+		if ( !in_array( get_post_type( $this->post_id ), $reply_types ) ) {
 			return false;
 		}
 

--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -385,6 +385,14 @@ class WPAS_Email_Notification {
 		if ( empty( $agent_id ) ) {
 			$agent_id = wpas_get_option( 'assignee_default', 1 );
 		}
+		
+		// If reply check if from agent
+		if ($this->ticket_id !== $this->post_id) {
+			$author_id = $this->get_reply()->post_author;
+			if ( user_can($author_id, 'edit_ticket') ) {
+				$agent_id = $author_id;
+			}
+		}
 
 		$agent  = get_user_by( 'id', (int) $agent_id  );
 		$client = get_user_by( 'id', $this->get_ticket()->post_author );

--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -91,7 +91,7 @@ class WPAS_Email_Notification {
 		}
 
 		if ( 'ticket_reply' !== get_post_type( $this->post_id ) &&
-			 'ticket_note' !== get_post_type($this->post_id) ) {
+		     'ticket_note' !== get_post_type($this->post_id) ) {
 			return false;
 		}
 
@@ -691,8 +691,9 @@ class WPAS_Email_Notification {
 		 * @param WP_User $user
 		 * @param string  $case
 		 * @param int     $ticket_id
+		 * @param int     $post_id
 		 */
-		$user = apply_filters( 'wpas_email_notifications_notify_user', $user, $case, $this->ticket_id );
+		$user = apply_filters( 'wpas_email_notifications_notify_user', $user, $case, $this->ticket_id, $this->post_id );
 
 		$recipients = $recipient_emails = array();
 		if (is_array($user)) {


### PR DESCRIPTION
I'm not sure if what I've done here is the best way to do it. But it seems that private notes of post type `ticket_note` are not supported in the WPAS_Email_Notification class. This won't actually send out e-mail notifications for private notes, but it will make the WPAS_Email_Notification class aware of them.

I have made two changes to the `wpas_email_notifications_notify_user` event: one that allows it to return multiple recipients and another that sends the `$post_id` or reply ID as that might be necessary for determining which users to notify. 