### PR TITLE
Better changes to email notifications

### DIFF
--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -734,11 +734,7 @@ class WPAS_Email_Notification {
 		$user = apply_filters( 'wpas_email_notifications_notify_user', $user, $case, $this->ticket_id, $this->post_id );
 
 		$recipients = $recipient_emails = array();
-		if (is_array($user)) {
-			$recipients = array_merge($recipients, $user);
-		} else {
-			$recipients[] = $user;
-		}
+		$recipients[] = $user;
 		
 		if( wpas_is_multi_agent_active() ) {
 			// We need to notify other agents
@@ -813,7 +809,8 @@ class WPAS_Email_Notification {
 			'attachments'     => ''
 			),
 			$case,
-			$this->ticket_id
+			$this->ticket_id, 
+			$this->post_id
 		);
 		
 		$attachments = array();


### PR DESCRIPTION
This change reverts a few lines I made in https://github.com/Awesome-Support/Awesome-Support/pull/620/commits/d64b344b30728d05abe01be768c3ca6a99a197b4 that allowed the `wpas_email_notifications_notify_user` filter to return an array of users. I now realize I can modify the array of recipients in the `wpas_email_notifications_email` filter instead. 

Additionally, I have passed in `$post_id` as the 4th parameter to the `wpas_email_notifications_email` parameter which can be very useful.

Previously see #633.