### PR TITLE
Don't try to guess the URL if running from WP-CLI

### DIFF
--- a/includes/functions-general.php
+++ b/includes/functions-general.php
@@ -189,6 +189,10 @@ function wpas_is_plugin_page( $slug = '' ) {
 
 		return false;
 
+	} elseif ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+		return false;
+
 	} else {
 
 		global $post;


### PR DESCRIPTION
Currently, using WP-CLI on a site where Awesome-Support is activated causes PHP Undefined index notices for SERVER_NAME and SERVER_PORT.  This patch avoids querying the URL if the plugin is being loaded from WP-CLI, rather than the web.