### PR TITLE
Add post_id to wpas_email_notifications_email filter.

### DIFF
--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -828,7 +828,8 @@ class WPAS_Email_Notification {
 			'attachments'     => ''
 			),
 			$case,
-			$this->ticket_id
+			$this->ticket_id, 
+			$this->post_id
 		);
 		
 		$attachments = array();


### PR DESCRIPTION
This update adds post_id to be send with the `wpas_email_notifications_email` filter. It was part of #637, that wasn't part of the array change that got glossed over and never made it in. Thanks.