### PR TITLE
Adding code for handling third argument for handling request for gett…

### DIFF
--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -1709,7 +1709,10 @@ function wpas_get_ticket_count_by_status( $state = '', $status = 'open' ) {
 		);
 
 	}
-
+	// if query arguments are set then combine query argument with $args varible
+	if( is_array( $query ) &&  count( $query ) > 0 ) {
+		$args = array_merge( $args, $query );
+	}
 	return count( wpas_get_tickets( $status, apply_filters( 'wpas_get_ticket_count_by_status_args',$args ) ) );
 
 }


### PR DESCRIPTION
…ing ticket count on basis of security profile.

Adding an optional query argument to the function is good. But it should be a general query arg. It looks like this is a very very specific arg just for taxonomies. Suggest you use a general wp_query style query arg instead so you can submit queries based on items other than just taxonomies. Drilling down into the wpas_get_tickets function you can see that it accepts a wp_query style argument so best to make it all consistent.