### PR TITLE
Fix bug where slashes are stripped from e-mail message.

### DIFF
--- a/includes/class-email-notifications.php
+++ b/includes/class-email-notifications.php
@@ -564,7 +564,7 @@ class WPAS_Email_Notification {
 	 * @return string E-mail body
 	 */
 	private function get_body( $case ) {
-		return apply_filters( 'wpas_email_notifications_body', stripcslashes ( $this->get_content( 'content', $case ) ), $this->post_id, $case );
+		return apply_filters( 'wpas_email_notifications_body', $this->get_content( 'content', $case ), $this->post_id, $case );
 	}
 
 	/**
@@ -625,7 +625,7 @@ class WPAS_Email_Notification {
 			$this->link_attachments = true;
 		}
 
-		return $this->fetch( $pre_fetch_content );
+		return $this->fetch( stripcslashes( $pre_fetch_content ) );
 		
 	}
 


### PR DESCRIPTION
In some instances slashes were being removed from the email notifications we were receiving. If a user entered in a Windows file path in the reply to a ticket like so:

`c:\windows\desktop\x`

Then the email notification would come across as:

`c:windowsdesktop\x`

This changes moves the call to `stripcslashes` from being applied on the e-mail's body - to being applied on the email's template. So instead of it being applied after the email tags have been evaluated, it is applied to the template before the tags are evaluated.