### PR TITLE
Add ability to show private notes on front end

### DIFF
--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -1182,7 +1182,9 @@ function wpas_get_replies( $post_id, $status = 'any', $args = array(), $output =
 
 	$defaults = array(
 		'post_parent'            => $post_id,
-		'post_type'              => 'ticket_reply',
+		'post_type'              => apply_filters( 'wpas_frontend_replies_post_type', [
+			'ticket_reply'
+		] ),
 		'post_status'            => $status,
 		'order'                  => wpas_get_option( 'replies_order', 'ASC' ),
 		'orderby'                => 'date',

--- a/themes/default/partials/ticket-reply.php
+++ b/themes/default/partials/ticket-reply.php
@@ -23,7 +23,7 @@ if ( ! defined( 'WPINC' ) ) {
 $user_role = $user->roles[0];
 ?>
 
-<tr id="reply-<?php echo the_ID(); ?>" class="wpas-reply-single wpas-status-<?php echo get_post_status(); ?> wpas_user_<?php echo $user_role; ?>" valign="top">
+<tr id="reply-<?php echo the_ID(); ?>" class="wpas-reply-single wpas-status-<?php echo get_post_status(); ?> wpas_user_<?php echo $user_role; ?> wpas-<?php echo str_replace("_", "-", get_post_type()); ?>" valign="top">
 
 	<?php
 	/**


### PR DESCRIPTION
This PR makes it so that you can view the private notes on the front end. They are only visible to those who have access. Private post types can then be stylized with something such as `.wpas-ticket-note {
	background-color: #F0F8FF;
}`

Because the email notifications include links to the front end in certain instances, that is where users might land (even admin users). Having the private notes visible on the front end immediately gives the agent visibility into the entire issue without having to go to the backend.