### PR TITLE
Update wpas_get_current_user_role()

### DIFF
--- a/includes/functions-general.php
+++ b/includes/functions-general.php
@@ -1476,7 +1476,7 @@ function wpas_get_current_user_role() {
 		
 		$user = wp_get_current_user();
 		$role = ( array ) $user->roles;
-		return array_shift($roles);
+		return array_shift($role);
 		
 	} else {
 		

--- a/includes/functions-general.php
+++ b/includes/functions-general.php
@@ -1476,7 +1476,7 @@ function wpas_get_current_user_role() {
 		
 		$user = wp_get_current_user();
 		$role = ( array ) $user->roles;
-		return $role[0];
+		return array_shift($roles);
 		
 	} else {
 		


### PR DESCRIPTION
To avoid add-on conflicts, use array_shift to return the first value of the array instead of $var[0] 

Some installs have this array's index starting at 1 instead of 0