### PR TITLE
Fix -doing-it-wrong missing permission callback

### DIFF
--- a/includes/rest-api/includes/API/Passwords.php
+++ b/includes/rest-api/includes/API/Passwords.php
@@ -92,9 +92,9 @@ class Passwords extends WP_REST_Controller {
 			array(
 				'methods' => WP_REST_Server::READABLE . ', ' . WP_REST_Server::CREATABLE,
 				'callback' => array( $this, 'test_basic_authorization_header' ),
+				'permission_callback' => '__return_true'
 			),
-			'schema' => array( $this, 'test_schema' ),
-			'permission_callback' => '__return_true' 
+			'schema' => array( $this, 'test_schema' )
 		) );
 
 	}

--- a/includes/rest-api/includes/API/Passwords.php
+++ b/includes/rest-api/includes/API/Passwords.php
@@ -94,6 +94,7 @@ class Passwords extends WP_REST_Controller {
 				'callback' => array( $this, 'test_basic_authorization_header' ),
 			),
 			'schema' => array( $this, 'test_schema' ),
+			'permission_callback' => '__return_true' 
 		) );
 
 	}


### PR DESCRIPTION
Small update to register_rest_route method for test_basic_authorization_header to remove 'doing it wrong' warning from Wordpress 