### PR TITLE
Remove variables from gettext functions

### DIFF
--- a/includes/admin/class-admin-tickets-list.php
+++ b/includes/admin/class-admin-tickets-list.php
@@ -515,12 +515,15 @@ class WPAS_Tickets_List {
 							$last_user      = get_user_by( 'id', $last_reply->post_author );
 							$role           = true === user_can( $last_reply->post_author, 'edit_ticket' ) ? _x( 'agent', 'User role', 'awesome-support' ) : _x( 'client', 'User role', 'awesome-support' );
 
-							echo _x( sprintf( _n( '%s reply.', '%s replies.', $replies->post_count, 'awesome-support' ), $replies->post_count ), 'Number of replies to a ticket', 'awesome-support' );
+							printf( _nx( '%s reply.', '%s replies.', $replies->post_count, 'Number of replies to a ticket', 'awesome-support' ), $replies->post_count );
 							echo '<br>';
-							printf( _x( '<a href="%s" target="' . $this->edit_link_target() . '">Last replied</a> %s ago by %s (%s).', 'Last reply ago', 'awesome-support' ), add_query_arg( array(
-								                                                                                                                                                                 'post'   => $post_id,
-								                                                                                                                                                                 'action' => 'edit',
-							                                                                                                                                                                 ), admin_url( 'post.php' ) ) . '#wpas-post-' . $last_reply->ID, human_time_diff( strtotime( $last_reply->post_date ), current_time( 'timestamp' ) ), '<a href="' . $last_user_link . '">' . $last_user->user_nicename . '</a>', $role );
+							printf( _x( '<a href="%1$s" target="%2$s">Last replied</a> %3$s ago by %4$s (%5$s).', 'Last reply ago', 'awesome-support' ),
+								add_query_arg( array(
+									'post'   => $post_id,
+									'action' => 'edit',
+								), admin_url( 'post.php' ) ) . '#wpas-post-' . $last_reply->ID,
+								$this->edit_link_target(), human_time_diff( strtotime( $last_reply->post_date ), current_time( 'timestamp' ) ), '<a href="' . $last_user_link . '">' . $last_user->user_nicename . '</a>', $role
+							);
 						}
 
 						// Add open date
@@ -1334,7 +1337,7 @@ SQL;
 				$tax_obj = get_taxonomy( $tax_slug );
 
 				$args = array(
-					'show_option_all' => __( 'All ' . $tax_obj->label ),
+					'show_option_all' => sprintf( _x( 'All %s', 'Placeholder is a taxonomy object label', 'awesome-support' ), $tax_obj->label ),
 					'taxonomy'        => $tax_slug,
 					'name'            => $tax_obj->name,
 					'orderby'         => 'name',

--- a/includes/gdpr-integration/gdpr-privacy-options.php
+++ b/includes/gdpr-integration/gdpr-privacy-options.php
@@ -404,7 +404,9 @@ class WPAS_Privacy_Option {
 										);
 										?>
 										<a href="<?php echo wpas_tool_link( 'add_user_consent', $opt_out ); ?>" class="button-secondary"><?php _e( 'OPT-OUT', 'awesome-support' ); ?></a>
-										<span class="wpas-system-tools-desc"><?php _e( 'Set ' . $consent_name . ' Consent status for all Awesome support Users', 'awesome-support' ); ?></span>
+										<span class="wpas-system-tools-desc"><?php
+											printf( _x( 'Set %s Consent status for all Awesome support Users', 'Placeholder is consent name eg Terms', 'awesome-support' ), $consent_name );
+										?></span>
 									</td>
 								</tr>
 								<?php 
@@ -751,7 +753,7 @@ class WPAS_Privacy_Option {
 									foreach ( $value as $reply_key => $reply_data ) {
 										$reply_count ++;
 										if( isset( $reply_data['content'] ) && !empty( $reply_data['content'] )){
-											$name = __( 'Reply ' . $reply_count . ' Content', 'awesome-support' );
+											$name = sprintf( __( 'Reply %d Content', 'awesome-support' ), $reply_count );
 											if ( ! empty( $value ) ) {
 												$user_data_to_export[] = array(
 													'name'  => $name,

--- a/includes/gdpr-integration/gdpr-user-profile.php
+++ b/includes/gdpr-integration/gdpr-user-profile.php
@@ -72,10 +72,10 @@ class WPAS_GDPR_User_Profile {
 				header( 'Expires: 0' );
 				readfile( $this->user_export_dir . '/exported-data.zip' );
 				if (!unlink($this->user_export_dir . '/exported-data.zip') ){
-					return new WP_Error( 'file_deleting_error', __( 'Error deleting ' . $this->user_export_dir . '/exported-data.zip', 'awesome-support' ) );
+					return new WP_Error( 'file_deleting_error', sprintf( __( 'Error deleting %s', 'awesome-support' ), $this->user_export_dir . '/exported-data.zip' ) );
 				}
 				if (!unlink($this->user_export_dir . '/export-data.xml') ){
-					return new WP_Error( 'file_deleting_error', __( 'Error deleting ' . $this->user_export_dir . '/export-data.xml', 'awesome-support' ) );
+					return new WP_Error( 'file_deleting_error', sprintf( __( 'Error deleting %s', 'awesome-support' ), $this->user_export_dir . '/export-data.xml' ) );
 				}
 			} else {
 				return new WP_Error( 'security_error', __( 'Request not identified, Invalid request', 'awesome-support' ) );

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -420,7 +420,7 @@ function wpas_get_javascript_object() {
 		'useAutolinker'          => true === boolval( wpas_get_option( 'use_autolinker', true ) ) ? 'true' : 'false',
 		'fileUploadMax'          => $upload_max_files,
 		'fileUploadSize'         => $upload_max_size * 1048576, // We base our calculation on binary prefixes
-		'fileUploadMaxError'     => __( sprintf( 'You can only upload a maximum of %d files', $upload_max_files ), 'awesome-support' ),
+		'fileUploadMaxError'     => sprintf( __( 'You can only upload a maximum of %d files', 'awesome-support' ), $upload_max_files ),
 		'fileUploadMaxSizeError' => array(
 			__( 'The following file(s) are too big to be uploaded:', 'awesome-support' ),
 			sprintf( __( 'The maximum file size allowed for one file is %d MB', 'awesome-support' ), $upload_max_size )


### PR DESCRIPTION
The text for gettext functions like _x() should always be static – if it includes variables it’s impossible to translate.

This corrects a few examples of variables in the text, using sprintf placeholders instead.

The .pot file will need to be regenerated afterwards to pick up the new strings.

Thanks