### PR TITLE
Check for array when mapping the `name` argument.

### DIFF
--- a/includes/class-product-sync.php
+++ b/includes/class-product-sync.php
@@ -234,7 +234,13 @@ class WPAS_Product_Sync {
 
 				case 'slug':
 				case 'name':
-					$clean_args['name'] = sanitize_title( $value );
+					if ( is_array( $value ) ) {
+						$name = reset( $value );
+						// `reset()` can return false && there is always the possibility that the first array item is not an array, so check for a string.
+						$clean_args['name'] = is_string( $name ) ? sanitize_title( $name ) : '';
+					} elseif ( is_string( $value ) ) {
+						$clean_args['name'] = sanitize_title( $value );
+					}
 					break;
 
 				case 'parent':


### PR DESCRIPTION
When mapping the get terms query, the `name` argument can be an array causing PHP warnings to be thrown when run through `sanitize_title()`.

Check for an array, grab the first array item, and sanitize that value instead. If it is a string, sanitize and break.