### PR TITLE
Trying to get property 'count' of non-object. 

### DIFF
--- a/includes/class-product-sync.php
+++ b/includes/class-product-sync.php
@@ -602,7 +602,7 @@ class WPAS_Product_Sync {
 
 		    }
 
-			if ( false !== $term ) {
+			if ( is_object( $term ) ) {
 
 				$new_terms[] = apply_filters( 'wpas_get_terms_term', $term, $this->taxonomy );
 


### PR DESCRIPTION
The `\WPAS_Product_Sync::get_terms()` function is a callback for the core WP `get_terms`. This filter does not always return an object. Check for an object instead of `false`.