### PR TITLE
Fix file uploads

### DIFF
--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -848,7 +848,7 @@ class WPAS_File_Upload {
 		$attachments = new WPAS_Custom_Field( $this->index, $attachments_args );
 		echo wp_kses($attachments->get_output(), ['label' => [
 			'for' => true, ], 'input' => [ 'style' => true, 'accept' => true, 'multiple', 'type' => true, 'value' => true, 'id' => true,
-			'class' => true, 'name' => true, 'readonly' => true, ], 'div' => [ 'class' => true,'id' => true]]);
+			'class' => true, 'name' => true, 'readonly' => true, ], 'div' => [ 'class' => true,'id' => true, 'data-ticket-id' => true]]);
 
 	}
 


### PR DESCRIPTION
I was running into an issue uploading files on tickets on my site

It _seems_ like the script [here](https://github.com/Awesome-Support/Awesome-Support/blob/develop/assets/admin/js/admin-ajax-upload.js#L21) depends on the "dropzone" div having a `data-ticket-id` attribute

That attribute is set [here](https://github.com/Awesome-Support/Awesome-Support/blob/develop/includes/custom-fields/field-types/class-cf-upload.php#L91)

But it seems like that attribute is stripped out [here](https://github.com/Awesome-Support/Awesome-Support/blob/develop/includes/file-uploader/class-file-uploader.php#L849-L851)

_Presumably_ this was working before because `#post_ID` was somewhere on the page, but I just swapped over to a block theme and it doesn't seem like that is the case anymore

So I just added `data-ticket-id` to the "allowed" attributes that are passed to `wp_kses` before display

This fixes uploading files to tickets on my site

Thanks!