### PR TITLE
Fix. Allow 'multiple' attribute for files attach input field

### DIFF
--- a/includes/file-uploader/class-file-uploader.php
+++ b/includes/file-uploader/class-file-uploader.php
@@ -130,7 +130,7 @@ class WPAS_File_Upload
 				'for' => true, 'class' => true
 			],
 			'input' => [
-				'style' => true, 'accept' => true, 'multiple', 'type' => true, 'value' => true, 'id' => true, 'pattern' => true,
+				'style' => true, 'accept' => true, 'multiple' => true, 'type' => true, 'value' => true, 'id' => true, 'pattern' => true,
 				'class' => true, 'name' => true, 'readonly' => true, 'required' => true, 'spellcheck' => true, 'placeholder' => true
 			],
 			'span' => [], 'code' => [],


### PR DESCRIPTION
This typo in associative array in fact removes the multiply attribute from `<input type="file">` and users can't attach a number of files into the ticket.  