### PR TITLE
Swap `#post_ID` for `input[name=ticket_id]` for file uploads

### DIFF
--- a/assets/admin/js/admin-ajax-upload.js
+++ b/assets/admin/js/admin-ajax-upload.js
@@ -18,7 +18,7 @@
 
             var id    = $(e).attr('id');
             var paste = $(this).data('enable-paste');
-            ticket_id = (  $('#post_ID').length ) ? $('#post_ID').val() : $(this).data('ticket-id');
+            ticket_id = (  $('input[name=ticket_id]').length ) ? $('input[name=ticket_id]').val() : $(this).data('ticket-id');
             var dropzone_id = $(this).attr('id').substr(9);
 
             $('#' + id).dropzone({ 


### PR DESCRIPTION
No HTML element matching `#post_ID` seems to exist anymore in a block-based world? This results in users not being able to upload files

I was able to swap that reference out for something like `input[name=ticket_id]` and now file uploads are successfully completing again