### PR TITLE
FIX BUG on 6.3.3. DEV -  hyperlink tool on Editor

### DIFF
--- a/includes/functions-general.php
+++ b/includes/functions-general.php
@@ -2242,6 +2242,12 @@ if( !function_exists( 'wpas_get_allowed_html_tags' ) ) {
 				'width' => true,
 				'usemap'=> true,			
 			], 
+			'link' => [
+				'rel' => true,
+				'id' => true,
+				'href' => true,	
+				'media' => true,	
+			],
 			'a' => [
 				'download' => true,
 				'href' => true,


### PR DESCRIPTION
The Editor of Ticket content jumps to another part if User tries to add hyperlink tool on Editor.